### PR TITLE
Altera estrutura do Footer para conter apenas páginas da Impulso e Termos

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -164,7 +164,7 @@ function MyApp(props) {
                   copyright: props.res[0].copyrights[0].copyright,
                   email: props.res[0].copyrights[0].contato,
               }}
-              links={ props.ses ? [props.res[0].menus[1],props.res[0].menus[4]] :  [props.res[0].menus[0],props.res[0].menus[1],props.res[0].menus[3],props.res[0].menus[4],props.res[0].menus[7]]}
+              links={ [props.res[0].menus[0],props.res[0].menus[7]] }
               socialMediaURLs={[
                 { url: props.res[0].socialMedias[0].url, logo: props.res[0].socialMedias[0].logo[0].url},
                 { url: props.res[0].socialMedias[1].url, logo: props.res[0].socialMedias[1].logo[0].url},

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -164,7 +164,7 @@ function MyApp(props) {
                   copyright: props.res[0].copyrights[0].copyright,
                   email: props.res[0].copyrights[0].contato,
               }}
-              links={ props.ses ? [props.res[0].menus[1],props.res[0].menus[4]] :  [props.res[0].menus[0],props.res[0].menus[1],props.res[0].menus[3]]}
+              links={ props.ses ? [props.res[0].menus[1],props.res[0].menus[4]] :  [props.res[0].menus[0],props.res[0].menus[1],props.res[0].menus[3],props.res[0].menus[4],props.res[0].menus[7]]}
               socialMediaURLs={[
                 { url: props.res[0].socialMedias[0].url, logo: props.res[0].socialMedias[0].logo[0].url},
                 { url: props.res[0].socialMedias[1].url, logo: props.res[0].socialMedias[1].logo[0].url},


### PR DESCRIPTION
Pensando no tamanho da navegação e na estrutura do footer, foi-se alterado as opções de navegação para incluir apenas a página "A Impulso Gov" e "Termos de uso e politica de privacidade."