### PR TITLE
[Fix] Atualiza props de TituloSmallTexto em gestão de usuários

### DIFF
--- a/componentes/ModalAutorizacoes/ModalAutorizacoes.jsx
+++ b/componentes/ModalAutorizacoes/ModalAutorizacoes.jsx
@@ -28,6 +28,10 @@ function ModalAutorizacoes({
           } }
           texto=''
           titulo={ titulo }
+          botao={{
+            label: '',
+            url: ''
+          }}
         />
 
         <div className={ styles.SelectContainer }>

--- a/componentes/ModalCadastroUsuario/ModalCadastroUsuario.jsx
+++ b/componentes/ModalCadastroUsuario/ModalCadastroUsuario.jsx
@@ -45,6 +45,10 @@ function ModalCadastroUsuario({
           } }
           texto=''
           titulo={ titulo }
+          botao={{
+            label: '',
+            url: ''
+          }}
         />
 
         <form className={ styles.Formulario }>


### PR DESCRIPTION
## Contexto do problema
A página de gestão de usuários passou a quebrar ao abrir os modais de edição de autorizações e de adição de novos usuários.

## Causa
A razão para a página quebrar é que, com a atualização recente do design system no repositório, o componente `TituloSmallTexto` passou a ter novas props que não estava sendo passadas para o componente na página de gestão de usuários.

## Solução
Atualização das props do componente `TituloSmallTexto` na página de gestão de usuários.