### PR TITLE
Ajustes textos Q3 2023 na área aberta

### DIFF
--- a/componentes/GraficoHistoricoAcaoEstrategica/GraficoHistoricoAcaoEstrategica.jsx
+++ b/componentes/GraficoHistoricoAcaoEstrategica/GraficoHistoricoAcaoEstrategica.jsx
@@ -44,27 +44,27 @@ const GraficoHistoricoAcaoEstrategica = ({ GrafAcaoEstrategica }) => {
       case 'M1':
         return 'Jan';
       case 'M2':
-        return 'Feb';
+        return 'Fev';
       case 'M3':
         return 'Mar';
       case 'M4':
-        return 'Apr';
+        return 'Abr';
       case 'M5':
-        return 'May';
+        return 'Mai';
       case 'M6':
         return 'Jun';
       case 'M7':
         return 'Jul';
       case 'M8':
-        return 'Aug';
+        return 'Ago';
       case 'M9':
-        return 'Sep';
+        return 'Set';
       case 'M10':
-        return 'Oct';
+        return 'Out';
       case 'M11':
         return 'Nov';
       case 'M12':
-        return 'Dec';
+        return 'Dez';
       default:
         return mes;
     }

--- a/componentes/GraficoValorConsolidado/GraficoValorConsolidado.jsx
+++ b/componentes/GraficoValorConsolidado/GraficoValorConsolidado.jsx
@@ -37,27 +37,27 @@ const GraficoValorConsolidado = ({ GrafValorConsolidado }) => {
       case 'M1':
         return 'Jan';
       case 'M2':
-        return 'Feb';
+        return 'Fev';
       case 'M3':
         return 'Mar';
       case 'M4':
-        return 'Apr';
+        return 'Abr';
       case 'M5':
-        return 'May';
+        return 'Mai';
       case 'M6':
         return 'Jun';
       case 'M7':
         return 'Jul';
       case 'M8':
-        return 'Aug';
+        return 'Ago';
       case 'M9':
-        return 'Sep';
+        return 'Set';
       case 'M10':
-        return 'Oct';
+        return 'Out';
       case 'M11':
         return 'Nov';
       case 'M12':
-        return 'Dec';
+        return 'Dez';
       default:
         return mes;
     }

--- a/componentes/TabelaIndicadores/TabelaIndicadores.jsx
+++ b/componentes/TabelaIndicadores/TabelaIndicadores.jsx
@@ -114,7 +114,7 @@ const TabelaIndicadores = ({ TabIndicadores }) => {
     },
     {
       field: 'delta_formatado',
-      headerName: 'Variação de desempenho de Q1-23/Q2-23',
+      headerName: 'Variação de desempenho de Q2-23/Q3-23',
       flex: 2,
       align: 'center',
       headerAlign: 'center',

--- a/componentes/indicadores/index.js
+++ b/componentes/indicadores/index.js
@@ -95,7 +95,7 @@ const Indicadores = ({
         }}
         supertitulo=""
         texto="Abaixo você encontrará algumas informações para te ajudar a melhorar o desempenho dos indicadores, como: <b> quão perto de 85% o denominador informado está </b> , o <b> número total de pessoas </b> que devem ser atendidas para bater a meta de cada indicador, dessas pessoas, <b>quantas pessoas ainda precisam ser cadastradas antes do atendimento</b>, a <b>variação percentual de desempenho da competência atual para a anterior</b>,  e <b>recomendações</b> de como bater as metas. <br><br> A disposição dos indicadores na tabela é uma sugestão feita pela nosso time de especialistas de como os municípios podem alocar esforços para a melhoria dos indicadores que ainda não atingiram a meta. Foram levados em consideração: o peso do indicador, tempo de aferição, nota do indicador e quanto falta para alcançar a meta. </br> "
-        titulo="<b>Como melhorar o desempenho dos indicadores - 2023.Q2 </b>" tooltip="" />
+        titulo="<b>Como melhorar o desempenho dos indicadores - 2023.Q3 </b>" tooltip="" />
 
       <TabelaIndicadores
         TabIndicadores={indicadoresData}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -147,7 +147,7 @@ function MyApp(props) {
                             ]
                           }] : [])
                       .concat(props.ses?.user.perfis.includes(7) ? [{ label: "Trilhas", url: "/capacitacoes" }] : [])
-                      .concat([{ label: "Dados Públicos - Q2/23", url: "/analise" }])
+                      .concat([{ label: "Dados Públicos - Q3/23", url: "/analise" }])
                     : [props.res[0].menus[0], props.res[0].menus[1]].concat([{ label: "Apoio aos Municípios", url: "/apoio" },{ label: "FAQ", url: "/faq" } , { label: "Blog", url: "/blog" }]) }
                 NavBarIconBranco={ props.res[0].logoMenuMoblies[0].logo.url }
                 NavBarIconDark={ props.res[0].logoMenuMoblies[1].logo.url }


### PR DESCRIPTION
### Descrição
Com a disponibilização dos dados do Q3 2023, é necessário ajustar alguns textos na plataforma.

### Objetivos
- Alterar os textos nos componentes da área aberta listados [aqui](https://www.notion.so/impulsogov/Checklist-Mudan-a-de-quadrimestre-IP-c009e7825ae4457698d2b979bbd426c5)
- Exibir em pt-br as abreviações dos meses nos gráficos de ações estratégicas

### Checklist de validação
- [ ] Todos os campos da área aberta listados [aqui](https://www.notion.so/impulsogov/Checklist-Mudan-a-de-quadrimestre-IP-c009e7825ae4457698d2b979bbd426c5) exibem o texto do Q3 2023
- [ ] Os gráficos de ações estratégicas exibem os meses em pt-br