### PR TITLE
Corrige regra de usuário teste mixpanel

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -78,7 +78,7 @@ function MyApp(props) {
         "municipio": props.ses.user.municipio,
         "equipe": props.ses.user.equipe,
         "municipio_id_sus": props.ses.user.municipio_id_sus,
-        "is_test_user": (props.ses.user.cargo == 'Impulser') && !props.ses.user.mail.includes('@impulsogov.org') && !props.ses.user.municipio.includes('Impulsolândia')
+        "is_test_user": (props.ses.user.cargo == 'Impulser') || props.ses.user.mail.includes('@impulsogov.org') || props.ses.user.municipio.includes('Impulsolândia')
       });
     }
   }, [props.ses]);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -78,7 +78,10 @@ function MyApp(props) {
         "municipio": props.ses.user.municipio,
         "equipe": props.ses.user.equipe,
         "municipio_id_sus": props.ses.user.municipio_id_sus,
-        "is_test_user": (props.ses.user.cargo == 'Impulser') || props.ses.user.mail.includes('@impulsogov.org') || props.ses.user.municipio.includes('Impulsolândia')
+        "is_test_user": (props.ses.user.cargo == 'Impulser')
+          || props.ses.user.mail.includes('@impulsogov.org')
+          || props.ses.user.municipio.includes('Impulsolândia')
+          || props.ses.user.municipio.includes('Demo - Viçosa')
       });
     }
   }, [props.ses]);


### PR DESCRIPTION
### Descrição
A regra que define se um usuário é de teste ou não, no mixpanel, não estava funcionando corretamente, o que fez com que os usuários de teste não fossem identificados como tal, impactando a análise dos usuários que acessam a plataforma.

### Objetivos
- Corrigir regra que define um usuário como de teste para considerar todos aqueles que:
  - possuem o cargo _Impulser_
  - ou possuem email contendo _@impulsogov.org_
  - ou possuem município contendo _Impulsolândia_
 
### Checklist de validação
- [ ] Ao fazer login no link e acessar o mixpanel na aba _Users_, seu usuário deve possuir a propriedade `is_test_user = true`