### PR TITLE
Adiciona fonte sem serifa nas tabelas de impressão

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.175",
+    "@impulsogov/design-system": "^1.0.176",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.174",
+    "@impulsogov/design-system": "^1.0.175",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/pages/busca-ativa/citopatologico/index.js
+++ b/pages/busca-ativa/citopatologico/index.js
@@ -117,7 +117,7 @@ const IDFiltrosOrdenacaoCito = {
 }
 const Impressao = ()=> Imprimir(
     0.78,
-    <TabelaCitoImpressao data={tabelaData} colunas={colunasCito} status_usuario_descricao={status_usuario_descricao}/>,
+    <TabelaCitoImpressao data={tabelaData} colunas={colunasCito} status_usuario_descricao={status_usuario_descricao} fontFamily="sans-serif" />,
     "citopatologico",
     activeTitleTabIndex,
     activeTabIndex,

--- a/pages/busca-ativa/diabeticos/index.js
+++ b/pages/busca-ativa/diabeticos/index.js
@@ -98,7 +98,7 @@ const Index = ({res}) => {
   }
   const Impressao = ()=> Imprimir(
     0.78,
-    <TabelaHiperDiaImpressao data={tabelaData} colunas={colunasDiabetes}/>,
+    <TabelaHiperDiaImpressao data={tabelaData} colunas={colunasDiabetes} fontFamily="sans-serif" />,
     "diabetes",
     null,
     null,

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -110,14 +110,14 @@ const colunasImpressaoEquipe = {
 
 const ImpressaoEquipe = ()=> Imprimir(
   0.78,
-  <TabelaGestantesImpressao data={tabelaData} colunas={colunasImpressaoEquipe[activeTabIndex]}/>,
+  <TabelaGestantesImpressao data={tabelaData} colunas={colunasImpressaoEquipe[activeTabIndex]} fontFamily="sans-serif" />,
   "gestantes",
   activeTitleTabIndex,
   activeTabIndex,
 )   
 const ImpressaoAPS = ()=> Imprimir(
   0.78,
-  <TabelaGestantesImpressao data={tabelaData} colunas={colunasImpressao[activeTitleTabIndex]}/>,
+  <TabelaGestantesImpressao data={tabelaData} colunas={colunasImpressao[activeTitleTabIndex]} fontFamily="sans-serif" />,
   "gestantes",
   activeTitleTabIndex,
   activeTabIndex,

--- a/pages/busca-ativa/hipertensos/index.js
+++ b/pages/busca-ativa/hipertensos/index.js
@@ -82,7 +82,7 @@ const Index = ({res}) => {
   }
   const Impressao = ()=> Imprimir(
     0.78,
-    <TabelaHiperDiaImpressao data={tabelaData} colunas={colunasHipertensao}/>,
+    <TabelaHiperDiaImpressao data={tabelaData} colunas={colunasHipertensao} fontFamily="sans-serif" />,
     "hipertensao",
     null,
     null,

--- a/pages/busca-ativa/vacinacao/index.js
+++ b/pages/busca-ativa/vacinacao/index.js
@@ -79,7 +79,7 @@ import { colunasVacinacaoAPS } from "../../../helpers/colunasVacinacao";
 
   const ImpressaoVacinacao = ()=> Imprimir(
     1,
-    <TabelaVacinacaoImpressao data={tabelaData} colunas={colunasVacinacaoAPS}/>,
+    <TabelaVacinacaoImpressao data={tabelaData} colunas={colunasVacinacaoAPS} fontFamily="sans-serif" />,
     "vacinacao",
     activeTitleTabIndex,
     activeTabIndex,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.175":
-  version "1.0.175"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.175.tgz#109c0bf2d0816139baf8b8a1986254905fddb11d"
-  integrity sha512-Kxr52206jWekInP85x07+ioVG0BWMLl3F2qgMGeQtt9LHRaM/afB0pTvHfHjXybAztvHkNE3iCxXTal36lM4CA==
+"@impulsogov/design-system@^1.0.176":
+  version "1.0.176"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.176.tgz#19f8f7f99dfa12d2f6b98dfc88a3bc7f08ee38d0"
+  integrity sha512-t6hLPp+xgaIY6nZlKL650FOkpZ3MuLD5qC/SYnn4n8Xquz9DI1vRIhgAfX96OLX1E1O6jKgRXXvlAsskKar8ZQ==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.174":
-  version "1.0.174"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.174.tgz#dfc65419539e1375d3487c163f898c3e819aa67f"
-  integrity sha512-h5bSEzFho38ekQyPO2RGzdcB6RGC+SCOKMcoRsuvg4wheUd/gYa4ZcmDxXYiNjjWdEOsXeqHpUkEAZ7NFpaxFQ==
+"@impulsogov/design-system@^1.0.175":
+  version "1.0.175"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.175.tgz#109c0bf2d0816139baf8b8a1986254905fddb11d"
+  integrity sha512-Kxr52206jWekInP85x07+ioVG0BWMLl3F2qgMGeQtt9LHRaM/afB0pTvHfHjXybAztvHkNE3iCxXTal36lM4CA==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"


### PR DESCRIPTION
### Descrição
Embora a fonte Inter seja aplicada às tabelas de impressão diretamente no design system, ela não é aplicada quando a tabela é exibida no site do IP porque fontes e outros estilos importados não são executados na versão de impressão das tabelas. Por isso, é aplicada a fonte padrão do navegador, que possui serifa, o que dificulta a leitura dos dados na versão de impressão, sendo necessário aplicar alguma fonte sem serifa.

### Objetivos
- Aplicar fonte _sans-serif_ nas tabelas de impressão a partir da prop `fontFamily`

### Checklist de validação
- [ ] Todas as tabelas de impressão dos dados restritos usam fonte sem serifa nas visões de APS e equipe