### PR TITLE
[Área restrita] Corrige data usada para gerar quadrimestres

### DIFF
--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
@@ -23,7 +23,7 @@ const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Gestantes com DUM preenchida por total de consultas e captação
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Gestantes com DUM preenchida por total de consultas e captação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
@@ -21,7 +21,7 @@ const CardsGraficoIndicadorUmQuadriFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadrisFuturosFormatados} - Gestantes com DUM preenchida por total de consultas e captação
+            {quadrisFuturosFormatados && `${quadrisFuturosFormatados} -`} Gestantes com DUM preenchida por total de consultas e captação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const quadrisFuturos = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const quadrisFuturos = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const quadrisFuturos = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_futuro.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const quadrisFuturos = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const quadrisFuturos = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
@@ -23,7 +23,7 @@ const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const quadrisFuturos = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const quadrisFuturos = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 
@@ -18,7 +21,7 @@ const CardsGraficoIndicadorDoisQuadriFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadrisFuturosFormatados}  - Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
+            {quadrisFuturosFormatados} - Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const quadrisFuturos = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const quadrisFuturos = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
@@ -21,7 +21,7 @@ const CardsGraficoIndicadorDoisQuadriFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadrisFuturosFormatados} - Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
+            {quadrisFuturosFormatados && `${quadrisFuturosFormatados} -`} Gestantes com DUM preenchida por exames de Sífilis e HIV identificados por equipe de saúde
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_futuro.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const quadrisFuturos = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
@@ -23,7 +23,7 @@ const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? `Q${Object.values(dadosQuadriAtual).join("/")}`

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const quadrisFuturos = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
@@ -21,7 +21,7 @@ const CardsGraficoIndicadorTresQuadriFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadrisFuturosFormatados} - Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
+            {quadrisFuturosFormatados && `${quadrisFuturosFormatados} -`} Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
         </h2>
 
         <ScoreCardGrid

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const quadrisFuturos = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const quadrisFuturos = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 
@@ -18,7 +21,7 @@ const CardsGraficoIndicadorTresQuadriFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadrisFuturosFormatados}  - Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
+            {quadrisFuturosFormatados} - Gestantes com DUM preenchida por atendimento odontológico identificado por equipe de saúde
         </h2>
 
         <ScoreCardGrid

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_futuro.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q1' || item.gestacao_quadrimestre == '2024.Q2' || item.gestacao_quadrimestre == '2024.Q3')
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const quadrisFuturos = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const quadrisFuturos = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const quadrisFuturosFormatados = formatarQuadrimestres(quadrisFuturos, ' e ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreProximo = ({tabelaDataAPS}) =>{
     const dataQuadriProximo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 2)
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximoQuadri = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
+    const dataAtual = new Date().now();
+    const dadosProximoQuadri = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreProximo = ({tabelaDataAPS}) =>{
     const dataQuadriProximo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 2)
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximoQuadri = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
@@ -21,7 +21,7 @@ const CardsGraficoAPSQuadrimestreProximo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximoQuadriFormatado} - Crianças no período de vacinação
+            {proximoQuadriFormatado && `${proximoQuadriFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/graficoQuadrimestreProximo.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreProximo = ({tabelaDataAPS}) =>{
     const dataQuadriProximo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 2)
-    const dadosProximoQuadri = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente, 1)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximoQuadri = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,11 +38,9 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximoQuadri = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
+    const dataAtual = new Date().now();
+    const dadosProximoQuadri = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -57,7 +57,7 @@ const TabelaAPSQuadrimestreProximo = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximoQuadriFormatado} - Crianças no período de vacinação
+            {proximoQuadriFormatado && `${proximoQuadriFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosProximoQuadri = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente, 1)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximoQuadri = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,7 +38,7 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximoQuadri = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 1)
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
@@ -23,7 +23,7 @@ const CardsGraficoAPSQuadrimestreAtual = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Crianças no período de vacinação
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             key="vacinacaoCardsQuadriAtualGrafico"

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 1)
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/graficoQuadrimestreAtual.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreAtual = ({tabelaDataAPS}) =>{
     const dataQuadriAtual = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 1)
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -38,11 +38,9 @@ const TabelaAPSQuadrimestreAtual = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreAtual = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -59,7 +59,7 @@ const TabelaAPSQuadrimestreAtual = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Crianças no período de vacinação
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             key="vacinacaoCardsQuadriAtualTabela"

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -38,7 +38,7 @@ const TabelaAPSQuadrimestreAtual = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
@@ -2,8 +2,11 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 3)
-    const dadosProximosQuadris = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximosQuadris = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
@@ -21,7 +21,7 @@ const CardsGraficoAPSQuadrimestreFuturo = ({tabelaDataAPS}) =>{
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximosQuadrisFormatados} - Crianças no período de vacinação
+            {proximosQuadrisFormatados && `${proximosQuadrisFormatados} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
@@ -2,11 +2,9 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 3)
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximosQuadris = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosProximosQuadris = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/graficoQuadrimestreFuturo.js
@@ -2,7 +2,7 @@ import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-sy
 import { formatarQuadrimestres, obterDadosProximosQuadrimestres } from "../../../../../../utils/quadrimestre";
 const CardsGraficoAPSQuadrimestreFuturo = ({tabelaDataAPS}) =>{
     const dataQuadriFuturo = tabelaDataAPS?.filter(item => item.id_status_quadrimestre== 3)
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximosQuadris = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,11 +38,9 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximosQuadris = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosProximosQuadris = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosProximosQuadris = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximosQuadris = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -57,7 +57,7 @@ const TabelaAPSQuadrimestreFuturo = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximosQuadrisFormatados} - Crianças no período de vacinação
+            {proximosQuadrisFormatados && `${proximosQuadrisFormatados} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,7 +38,7 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0].id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximosQuadris = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -57,7 +57,7 @@ const TabelaAPSQuadrimestreProximo = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximoQuadriFormatado} - Crianças no período de vacinação
+            {proximoQuadriFormatado && `${proximoQuadriFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
         valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,11 +38,9 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximoQuadri = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
+    const dataAtual = new Date().now();
+    const dadosProximoQuadri = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,7 +38,7 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximoQuadri = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual, 1)
         : [];

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreProximo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosProximoQuadri = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente, 1)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximoQuadri = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente, 1)
         : [];
     const proximoQuadriFormatado = formatarQuadrimestres(dadosProximoQuadri);
 

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreAtual = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosQuadriAtual = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosQuadrimestre(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosQuadriAtual = dataMaisRecente
+        ? obterDadosQuadrimestre(dataMaisRecente)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -37,12 +37,9 @@ const TabelaAPSQuadrimestreAtual = ({
     const tabelaDataAPSVacinacao = tabelaDataAPS?.filter(item=>item.id_status_quadrimestre== 1)
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
-
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosQuadriAtual = dataMaisRecente
-        ? obterDadosQuadrimestre(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosQuadriAtual = dataAtual
+        ? obterDadosQuadrimestre(dataAtual)
         : null;
     const quadriAtualFormatado = dadosQuadriAtual
         ? formatarQuadrimestres([dadosQuadriAtual])

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -37,7 +37,7 @@ const TabelaAPSQuadrimestreAtual = ({
     const tabelaDataAPSVacinacao = tabelaDataAPS?.filter(item=>item.id_status_quadrimestre== 1)
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
         : null;

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -59,7 +59,7 @@ const TabelaAPSQuadrimestreAtual = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {quadriAtualFormatado} - Crianças no período de vacinação
+            {quadriAtualFormatado && `${quadriAtualFormatado} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             key="vacinacaoCardsQuadriAtualTabela"

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,11 +38,9 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
-    const dadosProximosQuadris = dataMaisRecente
-        ? obterDadosProximosQuadrimestres(dataMaisRecente)
+    const dataAtual = new Date().now();
+    const dadosProximosQuadris = dataAtual
+        ? obterDadosProximosQuadrimestres(dataAtual)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,8 +38,11 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dadosProximosQuadris = (tabelaDataAPS && tabelaDataAPS.length > 0)
-        ? obterDadosProximosQuadrimestres(tabelaDataAPS[0].dt_registro_producao_mais_recente)
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+        ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
+    const dadosProximosQuadris = dataMaisRecente
+        ? obterDadosProximosQuadrimestres(dataMaisRecente)
         : [];
     const proximosQuadrisFormatados = formatarQuadrimestres(dadosProximosQuadris.slice(-2), ' + ');
 

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -57,7 +57,7 @@ const TabelaAPSQuadrimestreFuturo = ({
             fontWeight: 500,
             lineHeight: "130%",
         }}>
-            {proximosQuadrisFormatados} - Crianças no período de vacinação
+            {proximosQuadrisFormatados && `${proximosQuadrisFormatados} -`} Crianças no período de vacinação
         </h2>
         <ScoreCardGrid
             valores={[

--- a/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/equipe/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -38,7 +38,7 @@ const TabelaAPSQuadrimestreFuturo = ({
     const codigosPolio = [10,20,30,40]
     if(tabelaDataAPSVacinacao[0]?.id_status_polio) tabelaDataAPSVacinacao.forEach(item => item.id_status_polio = codigosPolio[Number(item.id_status_polio)-1] ? codigosPolio[Number(item.id_status_polio)-1] : item.id_status_polio)
 
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const dadosProximosQuadris = dataAtual
         ? obterDadosProximosQuadrimestres(dataAtual)
         : [];

--- a/pages/busca-ativa/citopatologico/index.js
+++ b/pages/busca-ativa/citopatologico/index.js
@@ -126,9 +126,7 @@ const Impressao = ()=> Imprimir(
 if(session){  
     if(session.user.perfis.includes(9)){
         visao = "equipe"
-        const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
-            ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-            : [{}];
+        const dataAtual = new Date().now();
         const CardsChildSemExame = tabelaDataEquipe ? <ScoreCardGrid
         valores={[
             {
@@ -309,7 +307,7 @@ if(session){
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre data={dataMaisRecente} />
+        <MunicipioQuadrimestre data={dataAtual} />
         {
             tabelaData &&
             <PanelSelector
@@ -344,9 +342,7 @@ if(session){
 }
 if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-      : [{}];
+    const dataAtual = new Date().now();
     const CardsChild = tabelaDataAPS ? <ScoreCardGrid
         valores={[
             {
@@ -719,7 +715,7 @@ if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
             destaque="IMPORTANTE: "
             msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre data={dataMaisRecente} />
+        <MunicipioQuadrimestre data={dataAtual} />
         <PanelSelector
             components={[Children]}
             conteudo = "components"

--- a/pages/busca-ativa/citopatologico/index.js
+++ b/pages/busca-ativa/citopatologico/index.js
@@ -126,7 +126,7 @@ const Impressao = ()=> Imprimir(
 if(session){  
     if(session.user.perfis.includes(9)){
         visao = "equipe"
-        const dataAtual = new Date().now();
+        const dataAtual = Date.now();
         const CardsChildSemExame = tabelaDataEquipe ? <ScoreCardGrid
         valores={[
             {
@@ -342,7 +342,7 @@ if(session){
 }
 if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const CardsChild = tabelaDataAPS ? <ScoreCardGrid
         valores={[
             {

--- a/pages/busca-ativa/citopatologico/index.js
+++ b/pages/busca-ativa/citopatologico/index.js
@@ -126,6 +126,9 @@ const Impressao = ()=> Imprimir(
 if(session){  
     if(session.user.perfis.includes(9)){
         visao = "equipe"
+        const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
+            ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+            : [{}];
         const CardsChildSemExame = tabelaDataEquipe ? <ScoreCardGrid
         valores={[
             {
@@ -306,9 +309,7 @@ if(session){
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre
-            data={(tabelaDataEquipe && tabelaDataEquipe.length > 0) && tabelaDataEquipe[0].dt_registro_producao_mais_recente}
-        />
+        <MunicipioQuadrimestre data={dataMaisRecente} />
         {
             tabelaData &&
             <PanelSelector
@@ -343,6 +344,9 @@ if(session){
 }
 if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+      : [{}];
     const CardsChild = tabelaDataAPS ? <ScoreCardGrid
         valores={[
             {
@@ -715,9 +719,7 @@ if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
             destaque="IMPORTANTE: "
             msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre
-            data={(tabelaDataAPS && tabelaDataAPS.length > 0) && tabelaDataAPS[0].dt_registro_producao_mais_recente}
-        />
+        <MunicipioQuadrimestre data={dataMaisRecente} />
         <PanelSelector
             components={[Children]}
             conteudo = "components"

--- a/pages/busca-ativa/diabeticos/index.js
+++ b/pages/busca-ativa/diabeticos/index.js
@@ -122,7 +122,7 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
-      const dataAtual = new Date().now();
+      const dataAtual = Date.now();
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -236,7 +236,7 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     return (
       <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>

--- a/pages/busca-ativa/diabeticos/index.js
+++ b/pages/busca-ativa/diabeticos/index.js
@@ -122,9 +122,7 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
-      const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
-        ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
+      const dataAtual = new Date().now();
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -151,7 +149,7 @@ const Index = ({res}) => {
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
             />  
-            <MunicipioQuadrimestre data={dataMaisRecente} />
+            <MunicipioQuadrimestre data={dataAtual} />
 
             {
               tabelaDataEquipe &&
@@ -238,9 +236,7 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-      : [{}];
+    const dataAtual = new Date().now();
     return (
       <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -267,7 +263,7 @@ const Index = ({res}) => {
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre data={dataMaisRecente} />
+        <MunicipioQuadrimestre data={dataAtual} />
         {
           tabelaDataAPS &&
           <ScoreCardGrid

--- a/pages/busca-ativa/diabeticos/index.js
+++ b/pages/busca-ativa/diabeticos/index.js
@@ -122,6 +122,9 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
+      const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
+        ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -148,9 +151,7 @@ const Index = ({res}) => {
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
             />  
-            <MunicipioQuadrimestre
-              data={(tabelaDataEquipe && tabelaDataEquipe.length > 0) && tabelaDataEquipe[0].dt_registro_producao_mais_recente}
-            />
+            <MunicipioQuadrimestre data={dataMaisRecente} />
 
             {
               tabelaDataEquipe &&
@@ -237,6 +238,9 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+      : [{}];
     return (
       <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -263,9 +267,7 @@ const Index = ({res}) => {
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre
-          data={(tabelaDataAPS && tabelaDataAPS.length > 0) && tabelaDataAPS[0].dt_registro_producao_mais_recente}
-        />
+        <MunicipioQuadrimestre data={dataMaisRecente} />
         {
           tabelaDataAPS &&
           <ScoreCardGrid

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -128,7 +128,7 @@ const ImpressaoAPS = ()=> Imprimir(
 if(session){  
   if(session.user.perfis.includes(9)){
     visao = "equipe"
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const Children = [[
       [
         <CardsEquipe tabelaDataEquipe={tabelaDataEquipe}/>,
@@ -233,7 +233,7 @@ if(session){
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     const quadriAtualFormatado = dataAtual
       ? `${formatarQuadrimestres([obterDadosQuadrimestre(dataAtual)])}`
       : "";

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -128,6 +128,9 @@ const ImpressaoAPS = ()=> Imprimir(
 if(session){  
   if(session.user.perfis.includes(9)){
     visao = "equipe"
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
+      ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+      : [{}];
     const Children = [[
       [
         <CardsEquipe tabelaDataEquipe={tabelaDataEquipe}/>,
@@ -194,9 +197,7 @@ if(session){
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
       />  
-      <MunicipioQuadrimestre
-        data={(tabelaDataEquipe && tabelaDataEquipe.length > 0) && tabelaDataEquipe[0].dt_registro_producao_mais_recente}
-      />
+      <MunicipioQuadrimestre data={dataMaisRecente} />
       {
           tabelaData &&
           <PanelSelector
@@ -234,14 +235,14 @@ if(session){
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const dataAtualizacaoDados = (tabelaDataAPS && tabelaDataAPS.length > 0)
-      ? tabelaDataAPS[0].dt_registro_producao_mais_recente
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+      : [{}];
+    const quadriAtualFormatado = dataMaisRecente
+      ? `${formatarQuadrimestres([obterDadosQuadrimestre(dataMaisRecente)])}`
       : "";
-    const quadriAtualFormatado = dataAtualizacaoDados
-      ? `${formatarQuadrimestres([obterDadosQuadrimestre(dataAtualizacaoDados)])}`
-      : "";
-    const quadrisFuturosFormatados = dataAtualizacaoDados
-      ? formatarQuadrimestres(obterDadosProximosQuadrimestres(dataAtualizacaoDados), ' + ')
+    const quadrisFuturosFormatados = dataMaisRecente
+      ? formatarQuadrimestres(obterDadosProximosQuadrimestres(dataMaisRecente), ' + ')
       : "";
     const Children = [
         [
@@ -396,9 +397,7 @@ if(session){
             destaque="IMPORTANTE: "
             msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre
-          data={(tabelaDataAPS && tabelaDataAPS.length > 0) && tabelaDataAPS[0].dt_registro_producao_mais_recente}
-        />
+        <MunicipioQuadrimestre data={dataMaisRecente} />
         <CardsAPS tabelaDataAPS={tabelaDataAPS}/>
         <PanelSelector
             components={Children}

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -128,9 +128,7 @@ const ImpressaoAPS = ()=> Imprimir(
 if(session){  
   if(session.user.perfis.includes(9)){
     visao = "equipe"
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
-      ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-      : [{}];
+    const dataAtual = new Date().now();
     const Children = [[
       [
         <CardsEquipe tabelaDataEquipe={tabelaDataEquipe}/>,
@@ -197,7 +195,7 @@ if(session){
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
       />  
-      <MunicipioQuadrimestre data={dataMaisRecente} />
+      <MunicipioQuadrimestre data={dataAtual} />
       {
           tabelaData &&
           <PanelSelector
@@ -235,14 +233,12 @@ if(session){
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-      : [{}];
-    const quadriAtualFormatado = dataMaisRecente
-      ? `${formatarQuadrimestres([obterDadosQuadrimestre(dataMaisRecente)])}`
+    const dataAtual = new Date().now();
+    const quadriAtualFormatado = dataAtual
+      ? `${formatarQuadrimestres([obterDadosQuadrimestre(dataAtual)])}`
       : "";
-    const quadrisFuturosFormatados = dataMaisRecente
-      ? formatarQuadrimestres(obterDadosProximosQuadrimestres(dataMaisRecente), ' + ')
+    const quadrisFuturosFormatados = dataAtual
+      ? formatarQuadrimestres(obterDadosProximosQuadrimestres(dataAtual), ' + ')
       : "";
     const Children = [
         [
@@ -397,7 +393,7 @@ if(session){
             destaque="IMPORTANTE: "
             msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre data={dataMaisRecente} />
+        <MunicipioQuadrimestre data={dataAtual} />
         <CardsAPS tabelaDataAPS={tabelaDataAPS}/>
         <PanelSelector
             components={Children}

--- a/pages/busca-ativa/hipertensos/index.js
+++ b/pages/busca-ativa/hipertensos/index.js
@@ -106,7 +106,7 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
-      const dataAtual = new Date().now();
+      const dataAtual = Date.now();
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -220,7 +220,7 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const dataAtual = new Date().now();
+    const dataAtual = Date.now();
     return (
       <>
         <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>

--- a/pages/busca-ativa/hipertensos/index.js
+++ b/pages/busca-ativa/hipertensos/index.js
@@ -106,6 +106,9 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
+      const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
+        ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+        : [{}];
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -132,9 +135,7 @@ const Index = ({res}) => {
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
             />  
-            <MunicipioQuadrimestre
-              data={(tabelaDataEquipe && tabelaDataEquipe.length > 0) && tabelaDataEquipe[0].dt_registro_producao_mais_recente}
-            />
+            <MunicipioQuadrimestre data={dataMaisRecente} />
 
             {
               tabelaDataEquipe &&
@@ -221,6 +222,9 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
+    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
+      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
+      : [{}];
     return (
       <>
         <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -249,9 +253,7 @@ const Index = ({res}) => {
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre
-          data={(tabelaDataAPS && tabelaDataAPS.length > 0) && tabelaDataAPS[0].dt_registro_producao_mais_recente}
-        />
+        <MunicipioQuadrimestre data={dataMaisRecente} />
         {
           tabelaDataAPS &&
           <ScoreCardGrid

--- a/pages/busca-ativa/hipertensos/index.js
+++ b/pages/busca-ativa/hipertensos/index.js
@@ -106,9 +106,7 @@ const Index = ({res}) => {
   if(session){  
     if(session.user.perfis.includes(9)){
       visao = "equipe"
-      const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataEquipe && tabelaDataEquipe.length > 0)
-        ? tabelaDataEquipe.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-        : [{}];
+      const dataAtual = new Date().now();
         return (
         <>
           <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -135,7 +133,7 @@ const Index = ({res}) => {
                 destaque="IMPORTANTE: "
                 msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
             />  
-            <MunicipioQuadrimestre data={dataMaisRecente} />
+            <MunicipioQuadrimestre data={dataAtual} />
 
             {
               tabelaDataEquipe &&
@@ -222,9 +220,7 @@ const Index = ({res}) => {
   }
   if(session.user.perfis.includes(5) || session.user.perfis.includes(8)){
     visao = "aps"
-    const [{dt_registro_producao_mais_recente: dataMaisRecente = ""}] = (tabelaDataAPS && tabelaDataAPS.length > 0)
-      ? tabelaDataAPS.sort((a, b) => new Date(b.dt_registro_producao_mais_recente) - new Date(a.dt_registro_producao_mais_recente))
-      : [{}];
+    const dataAtual = new Date().now();
     return (
       <>
         <div style={{padding: "30px 80px 30px 80px",display: "flex"}}>
@@ -253,7 +249,7 @@ const Index = ({res}) => {
               destaque="IMPORTANTE: "
               msg="Os dados exibidos nesta plataforma refletem a base de dados local do município e podem divergir dos divulgados quadrimestralmente pelo SISAB. O Ministério da Saúde aplica regras de vinculação e validações cadastrais do usuário, profissional e estabelecimento que não são replicadas nesta ferramenta."
         />  
-        <MunicipioQuadrimestre data={dataMaisRecente} />
+        <MunicipioQuadrimestre data={dataAtual} />
         {
           tabelaDataAPS &&
           <ScoreCardGrid

--- a/utils/quadrimestre.js
+++ b/utils/quadrimestre.js
@@ -4,8 +4,8 @@ const QUANTIDADE_PADRAO_PROXIMOS_QUADRIMESTRES = 3;
 
 export const obterDadosQuadrimestre = (data) => {
   const objetoDeData = new Date(data);
-  const mes = objetoDeData.getUTCMonth() + 1; // ? +1 pra ficar de 1 a 12
-  const ano = String(objetoDeData.getUTCFullYear());
+  const mes = objetoDeData.getMonth() + 1; // ? +1 pra ficar de 1 a 12
+  const ano = String(objetoDeData.getFullYear());
   const quadrimestre = String(Math.ceil(mes / 4));
   return {
     quadrimestre,


### PR DESCRIPTION
### Descrição
Hoje foi notificado, [junto ao bug da data de produção mais recente na lista de vacinação](https://impulsogov.slack.com/archives/C04G8VCAC2G/p1709658815711899), que o texto do quadrimestre não estava correto na lista de vacinação, visão de APS, do município de Campos Novos - SC.

![image](https://github.com/ImpulsoGov/ImpulsoPrevine/assets/45800622/4911790c-8802-4967-8a79-de202522d485)

A causa desse problema foi a seguinte:
- Quando os textos de quadrimestre foram dinamizados, era selecionada a data de produção do primeiro elemento da lista de dados. Para o município Campo Novos - SC, esse primeiro elemento tinha data nula, o que gerava um objeto do tipo Date com ano igual 1970, por isso era mostrado o texto **Q1/70**.

**_IMPORTANTE_**: Em conversa com o time, entendemos que deveria ser usada a data atual para gerar os quadrimestres, e não a data de produção.

### Objetivos
- Usar a data atual para gerar os quadrimestres
- Remover os métodos de UTC na funções úteis de quadrimestre para exibir o quadrimestre de acordo com o a data/horário local do usuário

### Checklist de validação
- [ ] Os textos de quadrimestre são exibidos corretamente nas listas de Citopatológico, Diabetes, Hipertensão, Vacinação e Pré-natal, em todas as visões, de acordo com a data atual