### PR TITLE
aumenta limite de numero de resultados

### DIFF
--- a/utils/QUERYS.js
+++ b/utils/QUERYS.js
@@ -158,7 +158,7 @@ export const FAQ =
 
 export const POSTS = `
 {
-  blogArtigos {
+  blogArtigos (last: 100){
     autor
     avatar {
       url


### PR DESCRIPTION
### Descrição
A gerenciador de conteúdo (HYGRAPH) tem uma configuração padrão para retornar os 10 últimos resultados  de conteúdos registrados, no blog da plataforma ao se atingir o números de 12 artigos, os dois últimos não estavam retornando como resultado na chamada da API de conteúdo.

### Alterações
Na query de posts do blog foi alterada para retornar os últimos 100 resultados.

### Validação

- [ ] Verificar se todos os artigos estão sendo exibidos no blog (Atualmente 12)