### PR TITLE
[Gestão de usuários] Adiciona cargo e atualiza nome da demo

### DIFF
--- a/componentes/ModalCadastroUsuario/ModalCadastroUsuario.jsx
+++ b/componentes/ModalCadastroUsuario/ModalCadastroUsuario.jsx
@@ -117,7 +117,7 @@ function ModalCadastroUsuario({
             handleChange={ (event) => {
               setCargo(event.target.value);
             } }
-            width='30%'
+            width='60%'
           />
 
           <TextField
@@ -130,6 +130,15 @@ function ModalCadastroUsuario({
             } }
           />
 
+          <Select
+            label='Autorizações'
+            options={ autorizacoes }
+            selectedOptions={ autorizacoesSelecionadas }
+            handleChange={ handleAutorizacoesChange }
+            width='60%'
+            isMulti
+          />
+
           <TextField
             sx={ { width: '30%', m: 1 } }
             id='outlined-controlled'
@@ -138,15 +147,6 @@ function ModalCadastroUsuario({
             onChange={ (event) => {
               setEquipe(event.target.value);
             } }
-          />
-
-          <Select
-            label='Autorizações'
-            options={ autorizacoes }
-            selectedOptions={ autorizacoesSelecionadas }
-            handleChange={ handleAutorizacoesChange }
-            width='60%'
-            isMulti
           />
 
           <FormControlLabel

--- a/constants/gestaoUsuarios.js
+++ b/constants/gestaoUsuarios.js
@@ -20,6 +20,7 @@ export const CARGOS = [
   { id: 'Profissional de TI', descricao: 'Profissional de TI' },
   { id: 'Impulser', descricao: 'Impulser' },
   { id: 'Apoiador (a)', descricao: 'Apoiador (a)' },
+  { id: 'Coordenador (a) de Vigilância Epidemiológica', descricao: 'Coordenador (a) de Vigilância Epidemiológica' },
 ];
 
 export const ESTADOS_PERFIL_ATIVO = {

--- a/constants/municipios.js
+++ b/constants/municipios.js
@@ -9760,8 +9760,8 @@ export const MUNICIPIOS = [
     "municipioIdSus": "291077"
   },
   {
-    "nome": "Demo - Viçosa",
-    "uf": "MG",
+    "nome": "Demo - Bonfim",
+    "uf": "RR",
     "municipioIdSus": "111111"
   },
   {


### PR DESCRIPTION
### Descrição
Recentemente, o nome do município demo do Impulso Previne foi atualizado, então é necessário atualizar seu nome também no JSON usado para exibir as opções de municípios na gestão de usuários.
Além disso, houve também a necessidade de adicionar uma nova opção de cargo para cadastro de usuários.

### Objetivos
- Atualizar o nome do município demo para _Demo - Bonfim_ e sua uf para _RR_ no JSON de municípios
- Adicionar o cargo _Coordenador (a) de Vigilância Epidemiológica_ nas opções de cargo
- Aumentar a largura do seletor de cargo para ser possível ler os nomes de cargos por completo

### Checklist de validação
- [x] Ao pesquisar a palavra _Demo_ no seletor de municípios, **durante cadastro e atualização de usuários**, é exibida a única opção _Demo - Bonfim - RR_
- [x] É exibida a opção _Coordenador (a) de Vigilância Epidemiológica_ no seletor de cargos durante cadastro de usuário
- [x] É possível ler o nome de todos os cargos durante cadastro de usuário