### PR TITLE
[Mixpanel] Atualiza regra da propriedade is_test_user

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -81,7 +81,7 @@ function MyApp(props) {
         "is_test_user": (props.ses.user.cargo == 'Impulser')
           || props.ses.user.mail.includes('@impulsogov.org')
           || props.ses.user.municipio.includes('Impulsolândia')
-          || props.ses.user.municipio.includes('Demo - Viçosa')
+          || (props.ses.user.municipio_id_sus === '111111')
       });
     }
   }, [props.ses]);


### PR DESCRIPTION
### Descrição
Recentemente, o nome do município de demonstração da plataforma do Impulso Previne foi alterado, o que gerou a necessidade de atualização das funcionalidades que dependiam desse nome, sendo uma delas a definição de usuários de teste, que é usada no Mixpanel.
Essa dependência não é ideal, uma vez que o nome do município de demonstração é um dado que pode sofrer muitas alterações ao longo do tempo, trazendo a necessidade de ajustar a regra de usuário teste à cada mudança do nome. 

### Objetivos
- Alterar a regra de usuário teste do Mixpanel para substituir o uso do nome do município de demonstração pelo seu `id_sus`, que é um dado mais estável

### Checklist de validação
- Ao fazer login na plataforma e acessar a área _Users_ do Mixpanel, seu usuário possui o campo `is_test_user` igual a `true`