### PR TITLE
Quebra texto das abas na lista de pré-natal

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.206",
+    "@impulsogov/design-system": "^1.0.207",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.208",
+    "@impulsogov/design-system": "^1.0.209",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -413,7 +413,7 @@ if(session){
         <MunicipioQuadrimestre data={dataAtual} />
         <CardsAPS tabelaDataAPS={tabelaDataAPS}/>
         <PanelSelector
-            breakTitlesLine
+            breakLines
             components={Children}
             conteudo = "components"
             states={ {

--- a/pages/busca-ativa/gestantes/index.js
+++ b/pages/busca-ativa/gestantes/index.js
@@ -413,6 +413,7 @@ if(session){
         <MunicipioQuadrimestre data={dataAtual} />
         <CardsAPS tabelaDataAPS={tabelaDataAPS}/>
         <PanelSelector
+            breakTitlesLine
             components={Children}
             conteudo = "components"
             states={ {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.206":
-  version "1.0.206"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.206.tgz#bce4f410ec0a296b05529321f64ef5e3a0c3f203"
-  integrity sha512-GKwtClXLibb4/Yxzr0CoWF8VUlESpDq5oe07WAgprxYP8n8luy7iw+P+P0r/jS+v11A6cxb60hpZaldH5sJcAw==
+"@impulsogov/design-system@^1.0.207":
+  version "1.0.207"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.207.tgz#8df18da4351a20afee18f1492b71aa9cfc56ea4d"
+  integrity sha512-K2N32b3qgfZpaRutxopKGGSBAU7CcT96rxpd0cKVctYj9WvSz3jX3yCjdaJSZH2bOcFZN10gEfpHEinvPeGL5g==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.208":
-  version "1.0.208"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.208.tgz#bb21af9ca65f784c7136cf1cb441b4f243e8177d"
-  integrity sha512-I9bos+cVT1vN4oElZVcjHwZdYj1qvTpLMnGoV3/5hkP2tz1mq43qCXUukNtv/WkbBHKSb4A0skZoIaPtkVVzsg==
+"@impulsogov/design-system@^1.0.209":
+  version "1.0.209"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.209.tgz#932ed06ce913cdcff4e1e97ecc39c52d4571ba2e"
+  integrity sha512-Ad28dBRQo1puULU8qPOtat+joGT4W7vPyZhk6Fh5NZSPby+CSB3kPSDLvU5eK8xVOoLh4hXc3KccMeRTSeDM0w==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"


### PR DESCRIPTION
### Contexto
[Descrição da tarefa](https://www.notion.so/impulsogov/Aplicar-quebra-de-linha-no-texto-das-abas-do-seletor-de-pain-is-apenas-na-lista-de-pr-natal-ac34eb0258854a39933c7f332169b056?pvs=4)

### Objetivos
- Adicionar prop que quebra linha dos textos de aba e subaba do seletor de painéis na lista de pré-natal, visão APS

### Checklist de validação
- [ ] Quando a largura de tela está na faixa de 1365px - 640px, os textos das abas e subabas da lista de pré-natal não ultrapassam o limite da tela
- [ ] As listas de citopatológico e vacinação não fazem a quebra de linhas dos textos de aba e subaba independente da largura da tela