### PR TITLE
Remove evento de alerta de digitação de caracteres não numéricos no login

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.206",
+    "@impulsogov/design-system": "^1.0.208",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.206":
-  version "1.0.206"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.206.tgz#bce4f410ec0a296b05529321f64ef5e3a0c3f203"
-  integrity sha512-GKwtClXLibb4/Yxzr0CoWF8VUlESpDq5oe07WAgprxYP8n8luy7iw+P+P0r/jS+v11A6cxb60hpZaldH5sJcAw==
+"@impulsogov/design-system@^1.0.208":
+  version "1.0.208"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.208.tgz#bb21af9ca65f784c7136cf1cb441b4f243e8177d"
+  integrity sha512-I9bos+cVT1vN4oElZVcjHwZdYj1qvTpLMnGoV3/5hkP2tz1mq43qCXUukNtv/WkbBHKSb4A0skZoIaPtkVVzsg==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"


### PR DESCRIPTION
### Contexto
- Considerando o alto numero de disparos realizados pelo evento de digitação de caracteres não numéricos no login, conforme indicado nessa [thread](https://impulsogov.slack.com/archives/C05FNRDAJDA/p1714494461602409?thread_ts=1714494333.394589&cid=C05FNRDAJDA), se tornou muito alto para o plano contratado no mixpanel, sendo assim os times de analise e produto decidiram remover esse evento.

### Objetivos
- Remover o evento

### Checklist de validação
  - [x] Evento não é disparado para mixpanel