### PR TITLE
[Pré-natal] Corrige visualizações do quadrimestre atual

### DIFF
--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/grafico_indicador_1_atual.js
@@ -1,7 +1,7 @@
 import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-system";
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
-    const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriAtual = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
@@ -53,7 +53,7 @@ const CardsGraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{
 }
 
 const GraficoIndicadorUmQuadriAtual = ({tabelaDataAPS}) =>{ 
-    const dataQuadriFuturo = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriFuturo = tabelaDataAPS?.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     return tabelaDataAPS ? 
     <>
         <GraficoBuscaAtiva

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/grafico_indicador_2_atual.js
@@ -1,7 +1,7 @@
 import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-system";
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
-    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
@@ -51,7 +51,7 @@ const CardsGraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) =>{
     </> : <Spinner/>}
 
 const GraficoIndicadorDoisQuadriAtual = ({tabelaDataAPS}) => {
-    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     return tabelaDataAPS ? 
     <>
         <GraficoBuscaAtiva

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/grafico_indicador_3_atual.js
@@ -1,7 +1,7 @@
 import { GraficoBuscaAtiva, ScoreCardGrid, Spinner } from "@impulsogov/design-system";
 import { obterDadosQuadrimestre } from "../../../../../../utils/quadrimestre";
 const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
-    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     const dataAtual = Date.now();
     const dadosQuadriAtual = dataAtual
         ? obterDadosQuadrimestre(dataAtual)
@@ -45,7 +45,7 @@ const CardsGraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) =>{
 }
 
 const GraficoIndicadorTresQuadriAtual = ({tabelaDataAPS}) => {
-    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2023.Q3')
+    const dataQuadriAtual = tabelaDataAPS.filter(item => item.gestacao_quadrimestre == '2024.Q2')
     return dataQuadriAtual ? 
     <>
         <GraficoBuscaAtiva


### PR DESCRIPTION
### Contexto
Notou-se que o painel de pré-natal estava exibindo valores zerados nas abas do quadrimestre atual (Q2/2024) nos 3 indicadores.

### Objetivos
- Atualizar nome do quadrimestre usado para filtrar os dados nas abas do quadrimestre atual

### Checklist de validação
- [ ] Os dados são exibidos corretamente nas abas do quadrimestre atual (Q2/2024) nos 3 indicadores de pré-natal