### PR TITLE
[Quick wins] Pacote 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@hotjar/browser": "^1.0.9",
-    "@impulsogov/design-system": "^1.0.211",
+    "@impulsogov/design-system": "^1.0.212",
     "@mui/material": "^5.13.0",
     "@mui/x-data-grid": "^6.3.1",
     "@sentry/nextjs": "^7.92.0",

--- a/pages/analise/index.js
+++ b/pages/analise/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { v1 as uuidv1 } from 'uuid';
-import { Margem, NovoTituloTexto, CardIP, ButtonColor } from "@impulsogov/design-system"
+import { Margem, NovoTituloTexto, CardIP, ButtonColor , CardAlert } from "@impulsogov/design-system"
 
 const Index = ({ res }) => {
   const router = useRouter();
@@ -61,7 +61,15 @@ const Index = ({ res }) => {
           </>
         }
       />
-      
+
+      <CardAlert
+        background="#91D3DB"
+        padding="20px 30px"
+        margin="0 40px"
+        destaque="AVISO: "
+        msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
+      />
+
       <div className="cardGrid">
         {cardsData.map((card, index) => (
           <div key={uuidv1()} className="cardContainer">

--- a/pages/analise/index.js
+++ b/pages/analise/index.js
@@ -70,6 +70,7 @@ const Index = ({ res }) => {
           padding="20px 30px"
           margin="0 40px"
           color="#1F1F1F"
+          fontSize="16px"
           destaque="AVISO: "
           msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
         />

--- a/pages/analise/index.js
+++ b/pages/analise/index.js
@@ -70,9 +70,8 @@ const Index = ({ res }) => {
           padding="20px 30px"
           margin="0 40px"
           color="#1F1F1F"
-          fontSize="16px"
-          destaque="AVISO: "
-          msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
+          destaque={<span style={{fontSize: "16px"}}>AVISO: </span>}
+          msg={<span style={{fontSize: "16px"}}>Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde.</span>}
         />
       </div>
 

--- a/pages/analise/index.js
+++ b/pages/analise/index.js
@@ -62,13 +62,18 @@ const Index = ({ res }) => {
         }
       />
 
-      <CardAlert
-        background="#91D3DB"
-        padding="20px 30px"
-        margin="0 40px"
-        destaque="AVISO: "
-        msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
-      />
+      <div style={{
+        lineHeight: "24px"
+      }}>
+        <CardAlert
+          background="#91D3DB"
+          padding="20px 30px"
+          margin="0 40px"
+          color="#1F1F1F"
+          destaque="AVISO: "
+          msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
+        />
+      </div>
 
       <div className="cardGrid">
         {cardsData.map((card, index) => (

--- a/pages/dadoPublicos/index.js
+++ b/pages/dadoPublicos/index.js
@@ -57,13 +57,19 @@ const Index = ({ res }) => {
         texto=""
       />
 
+      <div style={{
+        lineHeight: "24px"
+      }}>
       <CardAlert
         background="#91D3DB"
         padding="20px 30px"
         margin="0 80px 60px 80px"
+        color="#1F1F1F"
+        fontSize="16px"
         destaque="AVISO: "
         msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
       />
+      </div>
 
       <MunicipioSelector
         municipios={data}

--- a/pages/dadoPublicos/index.js
+++ b/pages/dadoPublicos/index.js
@@ -60,15 +60,14 @@ const Index = ({ res }) => {
       <div style={{
         lineHeight: "24px"
       }}>
-      <CardAlert
-        background="#91D3DB"
-        padding="20px 30px"
-        margin="0 80px 60px 80px"
-        color="#1F1F1F"
-        fontSize="16px"
-        destaque="AVISO: "
-        msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
-      />
+        <CardAlert
+          background="#91D3DB"
+          padding="20px 30px"
+          margin="0 80px 60px 80px"
+          color="#1F1F1F"
+          destaque={<span style={{fontSize: "16px"}}>AVISO: </span>}
+          msg={<span style={{fontSize: "16px"}}>Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde.</span>}
+        />
       </div>
 
       <MunicipioSelector

--- a/pages/dadoPublicos/index.js
+++ b/pages/dadoPublicos/index.js
@@ -63,12 +63,21 @@ const Index = ({ res }) => {
         <CardAlert
           background="#91D3DB"
           padding="20px 30px"
-          margin="0 80px 60px 80px"
+          margin="0 80px"
           color="#1F1F1F"
           destaque={<span style={{fontSize: "16px"}}>AVISO: </span>}
           msg={<span style={{fontSize: "16px"}}>Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde.</span>}
         />
       </div>
+
+      <TituloTexto
+        imagem={{
+          posicao: null,
+          url: ''
+        }}
+        titulo=""
+        texto="<b>DIGITE O SEU MUNICIPIO ABAIXO</b>"
+      />
 
       <MunicipioSelector
         municipios={data}

--- a/pages/dadoPublicos/index.js
+++ b/pages/dadoPublicos/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useContext } from 'react';
 import { useRouter } from 'next/router';
 import { v1 as uuidv1 } from 'uuid';
-import { PanelSelector, TituloTexto, ScoreCardGrid, Margem } from "@impulsogov/design-system"
+import { PanelSelector, TituloTexto, ScoreCardGrid, Margem, CardAlert } from "@impulsogov/design-system"
 import Indicadores from "../../componentes/indicadores"
 import Cadastros from "../../componentes/cadastros"
 import Acoes from "../../componentes/acoes_estrategicas"
@@ -54,9 +54,17 @@ const Index = ({ res }) => {
           url: ''
         }}
         titulo="Resultados do Previne Brasil"
-        texto="Aqui você vai encontrar os resultados e informações do seu município, referentes a cada pilar do Previne Brasil: Indicadores de Desempenho, Capitação Ponderada e Ações Estratégicas. </br><br><b> DIGITE O SEU MUNICIPIO ABAIXO<b>"
+        texto=""
       />
-      
+
+      <CardAlert
+        background="#91D3DB"
+        padding="20px 30px"
+        margin="0 80px 60px 80px"
+        destaque="AVISO: "
+        msg="Os dados exibidos nessa página são referentes aos critérios do antigo Previne Brasil. As informações permanecem disponíveis para consulta, mas é importante ressaltar que, com o encerramento do programa, os resultados apresentados não devem ser considerados para o cofinanciamento da Atenção Primária à Saúde."
+      />
+
       <MunicipioSelector
         municipios={data}
         municipio={selectedMunicipio}

--- a/pages/index.js
+++ b/pages/index.js
@@ -75,22 +75,6 @@ const Index = ({res}) => {
                 titulo="<b>Suporte para coordenação e assistência da APS</b>"
                 texto="Melhore a atuação da sua unidade de saúde e do seu município com:"
               />
-            <Grid12Col
-            proporcao="7-5"
-            items={ [
-              <ImagensFull2 key="desempenho_imagem" imagem="https://media.graphassets.com/55Ovc152SoahfSNlqFIZ" />,
-              <><div style={{alignContent:"center"}}>
-                  <TituloSmallTexto
-                    key="desempenho"
-                    botao={{label: 'VER DESEMPENHO DOS MUNICÍPIOS',url: '/analise'}}
-                    imagem={{posicao: null,url: ''}}
-                    supertitulo="<b>Análises do Previne</b>"
-                    titulo=""
-                    texto="Veja o desempenho de qualquer município nos componentes do Previne Brasil e sugestões para alcançar as metas definidas.<br><br>"
-                  />
-                </div></>,
-            ] }
-          />
           <Grid12Col
             proporcao="5-7"
             items={ [

--- a/pages/quem-somos/index.js
+++ b/pages/quem-somos/index.js
@@ -81,6 +81,7 @@ const Index = ({ res }) => {
                     descricao="Semanalmente enviamos para o seu e-mail sugestões para melhorar sua rotina de trabalho e mantemos você informado sobre as atualizações da APS."
                     imagemSrc="https://media.graphassets.com/7KgUfR5QK24Tgxw79bIQ"
                     indicador="Conteúdos e materiais com dicas"
+                    imagemStyle={{ width: "65%" }}
                   />
                 </>,
                 <>
@@ -88,6 +89,7 @@ const Index = ({ res }) => {
                     imagemSrc="https://media.graphassets.com/RDN83YVAR6yBEpg8DOLE"
                     indicador="Capacitações com especialistas"
                     descricao="Realizamos eventos sobre temas específicos para todas as categorias de profissionais proporcionando uma troca com nossos especialistas."
+                    imagemStyle={{ width: "65%" }}
                   />
                 </>,
               ]}

--- a/pages/quem-somos/index.js
+++ b/pages/quem-somos/index.js
@@ -73,18 +73,10 @@ const Index = ({ res }) => {
               texto="No Impulso Previne, damos suporte para profissionais da gestão e da assistência sobre os indicadores da APS, com foco atualmente no Previne Brasil."
             />
 
-            <Grid12Col //Estou com um problema ao adicionar imagens aqui , acredito que terei que criar um novo componente tbm 
-              proporcao="4-4-4"
+            <Grid12Col
+              proporcao="6-6"
               items={[
                 <>
-                  <CardImg
-                    imagemSrc="https://media.graphassets.com/ZFonMyxQRLafcMm3Gk4J"
-                    indicador="Dados do SISAB organizados"
-                    descricao="Criamos painéis didáticos e descomplicados para você visualizar o desempenho nos indicadores de qualquer município do Brasil."
-                  />
-                </>,
-                <>
-
                   <CardImg
                     descricao="Semanalmente enviamos para o seu e-mail sugestões para melhorar sua rotina de trabalho e mantemos você informado sobre as atualizações da APS."
                     imagemSrc="https://media.graphassets.com/7KgUfR5QK24Tgxw79bIQ"

--- a/pages/quem-somos/index.js
+++ b/pages/quem-somos/index.js
@@ -81,7 +81,7 @@ const Index = ({ res }) => {
                     descricao="Semanalmente enviamos para o seu e-mail sugestões para melhorar sua rotina de trabalho e mantemos você informado sobre as atualizações da APS."
                     imagemSrc="https://media.graphassets.com/7KgUfR5QK24Tgxw79bIQ"
                     indicador="Conteúdos e materiais com dicas"
-                    imagemStyle={{ width: "65%" }}
+                    imagemStyle={{ width: "65%", margin: "auto" }}
                   />
                 </>,
                 <>
@@ -89,7 +89,7 @@ const Index = ({ res }) => {
                     imagemSrc="https://media.graphassets.com/RDN83YVAR6yBEpg8DOLE"
                     indicador="Capacitações com especialistas"
                     descricao="Realizamos eventos sobre temas específicos para todas as categorias de profissionais proporcionando uma troca com nossos especialistas."
-                    imagemStyle={{ width: "65%" }}
+                    imagemStyle={{ width: "65%", margin: "auto" }}
                   />
                 </>,
               ]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.211":
-  version "1.0.211"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.211.tgz#66529eaf30092b9f7baab07ad00410e9561a7000"
-  integrity sha512-RkN7NgW2SDBtY1PDwcfxkIhfyhYCylvAMtN0i7ZZ279rMCFz7oYqDE4Dbzn+CQQ35GV5zG3VMnr/x5MLKZo04Q==
+"@impulsogov/design-system@^1.0.212":
+  version "1.0.212"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.212.tgz#65a0b712fe41c865b0d8afdf3f566d7224098404"
+  integrity sha512-UXL6TI7HYwzw6cPUtjmbSEgYxLezoEMIOFgVvtKerOFYQ/pEA/TuuedBKm6+YBj/h/soTeQRp+R0ds2MreR6FQ==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"


### PR DESCRIPTION
### Contexto
[Detalhes da tarefa](https://www.notion.so/impulsogov/Pacote-5-PB-Desenvolvimento-e7bc812f4a2746b482c1200488229a55?pvs=4)

### Objetivos
- Remover seção sobre análises do previne na página inicial
- Remover card sobre dados do SISAB na página Quem somos
- Incluir mensagem sobre fim do Previne Brasil nas páginas de dados públicos

### Checklist de validação
- [x] Na página inicial, a seção sobre análises do previne não é exibida
- [x] Na página Quem somos, o card sobre dados do SISAB não é exibido
- [x] O banner com mensagem sobre o fim do programa é exibido nas páginas /analises e /dadosPublicos