### PR TITLE
[Hotjar] Adiciona evento em cadastros duplicados

### DIFF
--- a/pages/cadastros-duplicados/index.js
+++ b/pages/cadastros-duplicados/index.js
@@ -9,6 +9,7 @@ import { validatetoken} from "../../services/validateToken"
 import style from "../duvidas/Duvidas.module.css"
 import { redirectHome } from "../../helpers/redirectHome";
 import { log_out } from "../../hooks/log_out";
+import { hotjar } from "react-hotjar";
 export async function getServerSideProps(ctx) {
   const session = await getSession(ctx)
   const redirect = redirectHome(ctx,session)
@@ -82,7 +83,9 @@ const Index = ({res}) => {
       }
   })
   useEffect(()=>{log_out(session)},[session])
-
+  useEffect(() => {
+    hotjar.event("acesso_cadastros_duplicados");
+  }, [])
   useEffect(()=>{
     if(session && session?.user?.access_token){
       if(tokenValido!=true && tokenValido!==undefined) signOut()


### PR DESCRIPTION
### Contexto
Ultimamente, houve a necessidade de aplicar pesquisas no Impulso Previne a partir do Hotjar e, para isso, se tornou necessário fazer algumas configurações para seu uso.

### Objetivos
- Disparar evento via API do hotjar para avaliar seu uso no controle de pesquisas
- Validar uso de eventos do hotjar com integração de hotjar + mixpanel