### PR TITLE
Altera biblioteca do hotjar

### DIFF
--- a/helpers/eventosImpressaoHotjar.js
+++ b/helpers/eventosImpressaoHotjar.js
@@ -1,5 +1,5 @@
-import { hotjar } from "react-hotjar";
+import Hotjar from '@hotjar/browser';
 
 export function dispararEventoAbrirImpressaoAPS() {
-  hotjar.event("abrir_imprimir_lista_aps");
+  Hotjar.event("abrir_imprimir_lista_aps");
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-dom": "18.2.0",
     "react-ga": "^3.3.1",
     "react-gtm-module": "^2.0.11",
-    "react-hotjar": "^6.2.0",
     "validator": "^13.11.0"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,10 +20,12 @@ import { data } from '../utils/Municipios';
 import { LAYOUT } from '../utils/QUERYS';
 
 import mixpanel from 'mixpanel-browser';
-import { hotjar } from 'react-hotjar'
 import { log_out } from '../hooks/log_out';
+import Hotjar from '@hotjar/browser';
 
+const hotjarVersion = 6;
 
+Hotjar.init(Number(process.env["NEXT_PUBLIC_HOTJAR_SITE_ID"]), hotjarVersion);
 
 const tagManagerArgs = {
   gtmId: "GTM-W8RVZBL",
@@ -51,8 +53,6 @@ function MyApp(props) {
       // Expõe o mixpanel globalmente para permitir integração com o hotjar
       window.mixpanel = mixpanel;
     }
-
-    hotjar.initialize(3496492, 6);
   }, [])
 
   useEffect(() => {
@@ -91,7 +91,7 @@ function MyApp(props) {
         "$name": props.ses.user.nome,
         ...atributos
       });
-      hotjar.identify(props.ses.user.id, {
+      Hotjar.identify(props.ses.user.id, {
         "email": props.ses.user.mail,
         "name": props.ses.user.nome,
         ...atributos

--- a/pages/cadastros-duplicados/index.js
+++ b/pages/cadastros-duplicados/index.js
@@ -9,7 +9,6 @@ import { validatetoken} from "../../services/validateToken"
 import style from "../duvidas/Duvidas.module.css"
 import { redirectHome } from "../../helpers/redirectHome";
 import { log_out } from "../../hooks/log_out";
-import { hotjar } from "react-hotjar";
 export async function getServerSideProps(ctx) {
   const session = await getSession(ctx)
   const redirect = redirectHome(ctx,session)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,11 +4307,6 @@ react-gtm-module@^2.0.11:
   resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
   integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
 
-react-hotjar@^6.2.0:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/react-hotjar/-/react-hotjar-6.3.1.tgz#cce120c0fc5160056937fd646fc11a8b925b7294"
-  integrity sha512-EwMqL+ROSlKzatMhT/aqRq7XWWfzlnHynSBSTJh5M2O78mBiPohiSl4Ysls3HOQkkD9y6L22BW0c9bxK2JguwQ==
-
 react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
### Contexto
Anteriormente, usávamos a biblioteca `react-hotjar` para enviar dados ao hotjar e disparar eventos, mas percebemos que ela não estava funcionando corretamente, além de não ser a biblioteca oficial do hotjar.

### Objetivos
- Usar a biblioteca oficial `@hotjar/browser` no código para integração com hotjar
- Desinstalar biblioteca `react-hotjar`
- Adicionar o id do site como variável de ambiente