### PR TITLE
Adiciona informação de aba no título das listas impressas

### DIFF
--- a/componentes/mounted/busca-ativa/citopatologico/APS/TabelaAPSComExame.jsx
+++ b/componentes/mounted/busca-ativa/citopatologico/APS/TabelaAPSComExame.jsx
@@ -93,7 +93,7 @@ export const TabelaAPSComExame = ({
             })}
             trackObject={mixpanel}
             painel="aps"
-            lista="CITOPATOLÓGICO"
+            lista="<span>CITOPATOLÓGICO<span/><span style='display: block;'>PESSOAS EM DIA COM EXAME<span/>"
             divisorVertical={[1,4]}
             largura_colunas_impressao={{
                 paisagem: larguraColunasCitoPaisagemAPS,

--- a/componentes/mounted/busca-ativa/citopatologico/APS/TabelaAPSSemExame.jsx
+++ b/componentes/mounted/busca-ativa/citopatologico/APS/TabelaAPSSemExame.jsx
@@ -92,7 +92,7 @@ export const TabelaAPSSemExame = ({
         })}
         trackObject={mixpanel}
         painel="aps"
-        lista="CITOPATOLÓGICO"
+        lista="<span>CITOPATOLÓGICO<span/><span style='display: block;'>PESSOAS COM EXAME A SER REALIZADO<span/>"
         divisorVertical={[1,4]}
         largura_colunas_impressao={{
             paisagem: larguraColunasCitoPaisagemAPS,

--- a/componentes/mounted/busca-ativa/gestantes/APS/GestantesSemDUM/GestantesSemDum.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/GestantesSemDUM/GestantesSemDum.js
@@ -43,7 +43,7 @@ const TabelaGestantesSemDUM = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesSemDUM"
     painel="aps"
-    lista="GESTANTES SEM DUM"
+    lista="<span>PRÉ-NATAL<span/><span style='display: block;'>GESTANTES SEM DUM<span/>"
     divisorVertical = {[1,8]}
     largura_colunas_impressao={{
         paisagem : larguraColunasSemDumPaisagemAPS,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/tabelas/GestantesAtivas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/tabelas/GestantesAtivas.js
@@ -45,7 +45,7 @@ const IndicadorUmTabelaGestantesAtivas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesAtivas"
     painel="aps"
-    lista="PRÉ-NATAL - INDICADOR 1 (6 CONSULTAS)"
+    lista="<span>PRÉ-NATAL INDICADOR 1 (6 CONSULTAS)<span/><span style='display: block;'>GESTANTES ATIVAS<span/>"
     divisorVertical={[1,4]}
     largura_colunas_impressao={{
         paisagem : larguraColunasGestantesIndicador1Paisagem,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/tabelas/GestantesEncerradas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_1/tabelas/GestantesEncerradas.js
@@ -44,7 +44,7 @@ const IndicadorUmTabelaGestantesEncerradas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesEncerradas"
     painel="aps"
-    lista="PRÉ-NATAL INDICADOR 1 (6 CONSULTAS)"
+    lista="<span>PRÉ-NATAL INDICADOR 1 (6 CONSULTAS)<span/><span style='display: block;'>GESTANTES ENCERRADAS<span/>"
     divisorVertical = {[0,4]}
     largura_colunas_impressao={{
         paisagem : larguraColunasGestantesIndicador1Paisagem,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/tabelas/GestantesAtivas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/tabelas/GestantesAtivas.js
@@ -45,7 +45,7 @@ const IndicadorDoisTabelaGestantesAtivas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
         key="tabelaDataAPSGestantesAtivas"
         painel="aps"
-        lista="PRÉ-NATAL - INDICADOR 2 (EXAME DE HIV E SÍFILIS)"
+        lista="<span>PRÉ-NATAL INDICADOR 2 (EXAMES DE HIV E SÍFILIS)<span/><span style='display: block;'>GESTANTES ATIVAS<span/>"
         divisorVertical={[0,3]}
         largura_colunas_impressao={{
             paisagem : larguraColunasGestantesIndicador2Paisagem,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/tabelas/GestantesEncerradas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_2/tabelas/GestantesEncerradas.js
@@ -45,7 +45,7 @@ const IndicadorDoisTabelaGestantesEncerradas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesEncerradas"
     painel="aps"
-    lista="PRÉ-NATAL - INDICADOR 2 (EXAME DE HIV E SÍFILIS)"
+    lista="<span>PRÉ-NATAL INDICADOR 2 (EXAMES DE HIV E SÍFILIS)<span/><span style='display: block;'>GESTANTES ENCERRADAS<span/>"
     divisorVertical = {[0,3]}
     largura_colunas_impressao={{
         paisagem : larguraColunasGestantesIndicador2Paisagem,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/tabelas/GestantesAtivas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/tabelas/GestantesAtivas.js
@@ -45,7 +45,7 @@ const IndicadorTresTabelaGestantesAtivas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesAtivas"
     painel="aps"
-    lista="PRÉ-NATAL - INDICADOR 3 (ATENDIMENTO ODONTOLÓGICO)"
+    lista="<span>PRÉ-NATAL INDICADOR 3 (ATENDIMENTO ODONTOLÓGICO)<span/><span style='display: block;'>GESTANTES ATIVAS<span/>"
     divisorVertical = {[0,3]}
     largura_colunas_impressao={{
         paisagem : larguraColunasGestantesIndicador3Paisagem,

--- a/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/tabelas/GestantesEncerradas.js
+++ b/componentes/mounted/busca-ativa/gestantes/APS/indicador_3/tabelas/GestantesEncerradas.js
@@ -45,7 +45,7 @@ const IndicadorTresTabelaGestantesEncerradas = ({
     return tabelaDataAPS ? <PainelBuscaAtiva
     key="tabelaDataAPSGestantesEncerradas"
     painel="aps"
-    lista="PRÉ-NATAL - INDICADOR 3 (ATENDIMENTO ODONTOLÓGICO)"
+    lista="<span>PRÉ-NATAL INDICADOR 3 (ATENDIMENTO ODONTOLÓGICO)<span/><span style='display: block;'>GESTANTES ENCERRADAS<span/>"
     divisorVertical = {[0,3]}
     largura_colunas_impressao={{
         paisagem : larguraColunasGestantesIndicador3Paisagem,

--- a/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/proximo_quadrimestre/tabelaQuadrimestreProximo.js
@@ -157,7 +157,7 @@ const TabelaAPSQuadrimestreProximo = ({
 
         ]}
         painel="aps"
-        lista="VACINAÇÃO: POLIOMIELITE E PENTAVALENTE"
+        lista="<span>VACINAÇÃO: POLIOMIELITE E PENTAVALENTE<span/><span style='display: block;'>PRÓXIMO QUADRIMESTRE<span/>"
         divisorVertical={[2,4,6]}
         largura_colunas_impressao={{
             retrato: larguraColunasVacinacaoRetratoAPS,

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_atual/tabelaQuadrimestreAtual.js
@@ -159,7 +159,7 @@ const TabelaAPSQuadrimestreAtual = ({
                 },
             ]}
             painel="aps"
-            lista="VACINAÇÃO: POLIOMIELITE E PENTAVALENTE"
+            lista="<span>VACINAÇÃO: POLIOMIELITE E PENTAVALENTE<span/><span style='display: block;'>QUADRIMESTRE ATUAL<span/>"
             divisorVertical={[2,4,6]}
             largura_colunas_impressao={{
                 retrato: larguraColunasVacinacaoRetratoAPS,

--- a/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
+++ b/componentes/mounted/busca-ativa/vacinacao/aps/quadrimestre_futuro/tabelaQuadrimestreFuturo.js
@@ -156,7 +156,7 @@ const TabelaAPSQuadrimestreFuturo = ({
                 },
                 ]}
             painel="aps"
-            lista="VACINAÇÃO: POLIOMIELITE E PENTAVALENTE"
+            lista="<span>VACINAÇÃO: POLIOMIELITE E PENTAVALENTE<span/><span style='display: block;'>QUADRIMESTRES FUTUROS<span/>"
             divisorVertical={[2,4,6]}
             largura_colunas_impressao={{
                 retrato: larguraColunasVacinacaoRetratoAPS,


### PR DESCRIPTION
### Contexto
[Descrição da tarefa](https://linear.app/impulsogov/issue/ALOG-38/coaps-inserir-a-informacao-da-aba-da-lista-nominal-no-titulo-da-folha)

### Objetivos
- Atualizar títulos das listas impressas de Citopatológico, Pré-natal e Vacinação, visão APS, para inserir informações de suas abas

### Checklist de validação
- [ ] Os títulos das listas impressas de Citopatológico, Pré-natal e Vacinação estão de acordo com os critérios definidos na tarefa