### PR TITLE
Feature/alog-corrige-data-toolbar-mounted

### DIFF
--- a/src/componentes/mounted/lista-nominal/ToolBarMounted.tsx
+++ b/src/componentes/mounted/lista-nominal/ToolBarMounted.tsx
@@ -37,7 +37,7 @@ export const ToolBarMounted = ({
                     width={16}
                     />
                     <Text>
-                    LISTA ATUALIZADA EM: {updateDate}
+                        LISTA ATUALIZADA EM: {updateDate?.toLocaleDateString() ?? '-'}
                     </Text>
                 </Tag>
                 </Tooltip>


### PR DESCRIPTION
### Objetivos
- Converter data de atualização da lista para string antes da renderização para corrigir o erro:
```
Error: Objects are not valid as a React child (found: [object Date]).
```
- Adicionar valor padrão caso data de atualização seja indefinida