### PR TITLE
Configura o ReplaySessionSampleRate do Sentry

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -27,4 +27,4 @@ Sentry.init({
   debug: false,
 });
 
-console.log("SENTRY_SAMPLE_RATE:", process.env.SENTRY_REPLAY_SAMPLE_RATE);
+console.log("SENTRY_SAMPLE_RATE:", sampleRate);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,7 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-const sampleRate = parseFloat(process.env["SENTRY_REPLAY_SAMPLE_RATE"] || "0.1");
+const sampleRate = parseFloat(process.env["NEXT_PUBLIC_SENTRY_REPLAY_SAMPLE_RATE"] || "0.1");
 Sentry.init({
   dsn: process.env["NEXT_PUBLIC_SENTRY_DSN"],
 
@@ -27,4 +27,6 @@ Sentry.init({
   debug: false,
 });
 
-console.log("SENTRY_SAMPLE_RATE:", sampleRate);
+console.log("SENTRY_REPLAY_SAMPLE_RATE:", process.env.SENTRY_REPLAY_SAMPLE_RATE);
+console.log("NEXT_PUBLIC_SENTRY_REPLAY_SAMPLE_RATE:", process.env.NEXT_PUBLIC_SENTRY_REPLAY_SAMPLE_RATE);
+console.log("VERCEL_ENV:", process.env.VERCEL_ENV);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -27,4 +27,4 @@ Sentry.init({
   debug: false,
 });
 
-console.log("SENTRY_SAMPLE_RATE:", process.env.SENTRY_SAMPLE_RATE);
+console.log("SENTRY_SAMPLE_RATE:", process.env.SENTRY_REPLAY_SAMPLE_RATE);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -26,3 +26,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
+
+console.log("SENTRY_SAMPLE_RATE:", process.env.SENTRY_SAMPLE_RATE);

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,7 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-
+const sampleRate = parseFloat(process.env["SENTRY_REPLAY_SAMPLE_RATE"] || "0.1");
 Sentry.init({
   dsn: process.env["NEXT_PUBLIC_SENTRY_DSN"],
 
@@ -18,7 +18,7 @@ Sentry.init({
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: sampleRate,
 
   // Define how likely Replay events are sampled when an error occurs.
   replaysOnErrorSampleRate: 1.0,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -26,7 +26,3 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
-
-console.log("SENTRY_REPLAY_SAMPLE_RATE:", process.env.SENTRY_REPLAY_SAMPLE_RATE);
-console.log("NEXT_PUBLIC_SENTRY_REPLAY_SAMPLE_RATE:", process.env.NEXT_PUBLIC_SENTRY_REPLAY_SAMPLE_RATE);
-console.log("VERCEL_ENV:", process.env.VERCEL_ENV);


### PR DESCRIPTION
### Objetivos
- Modificar o replaySessionSampleRate de 0.1 para 1.0 em ambientes de testes( Vercel preview). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Configuração**
	- Adicionada configuração dinâmica para a taxa de amostragem de sessões no Sentry.
	- Permite personalização da taxa de amostragem através de variável de ambiente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->