### PR TITLE
feature/alog-263-adicionar-dados-de-usuario-no-contexto-de-eventos-do-sentry

### DIFF
--- a/src/app/SessionWrapperLayout.tsx
+++ b/src/app/SessionWrapperLayout.tsx
@@ -1,11 +1,28 @@
 'use client'
-import { SessionProvider } from "next-auth/react";
-import React from "react";
+import { SessionProvider, useSession } from "next-auth/react";
+import * as Sentry from "@sentry/nextjs";
+import React, { useEffect } from "react";
 interface SessionWrapperLayoutProps {
     children : React.ReactNode
 }
-export const SessionWrapperLayout : React.FC<SessionWrapperLayoutProps>= ({ children }) => {
-    return <SessionProvider refetchInterval={ 60 * 60 } refetchOnWindowFocus={ true }>
-        { children }
-    </SessionProvider>
-}
+const SentryUserSetter = () => {
+    const { data: session } = useSession();
+    useEffect(() => {
+      if (session?.user) {
+        Sentry.setUser({
+          id: session.user.id, 
+          username: session.user.nome,
+        });
+      }
+    }, [session]);
+  
+    return null; // This component doesn't render anything, it just updates Sentry
+  };
+  export const SessionWrapperLayout: React.FC<SessionWrapperLayoutProps> = ({ children }) => {
+    return (
+      <SessionProvider refetchInterval={60 * 60} refetchOnWindowFocus={true}>
+        <SentryUserSetter /> {/* This runs the user tracking logic */}
+        {children}
+      </SessionProvider>
+    );
+  };

--- a/src/app/api/auth/[...nextauth]/nextAuthOptions.ts
+++ b/src/app/api/auth/[...nextauth]/nextAuthOptions.ts
@@ -3,7 +3,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import axios from "axios"
 import FormData from "form-data"
 import { API_URL_USUARIOS } from "@constants/API_URL";
-
+import * as Sentry from "@sentry/nextjs";
 interface Credentials {
   username: string;
   password: string;
@@ -109,6 +109,14 @@ export const nextAuthOptions : NextAuthOptions = {
   pages: {
     signIn: '/inicio',
     signOut: '/auth/signout',
+  },
+  events: {
+   signIn:({user}) => {
+      Sentry.setUser({id:user.id})
+      console.log('signIn',user)
+   },
+    signOut:() => {
+        Sentry.setUser(null)
+    },
   }
 }
-


### PR DESCRIPTION
### Objetivos:
- Adicionar o userId ao contexto dos eventos do Sentry;
- Adicionar o userId no evento de SignIn do NextAuth

### Mudanças de configuração:
Para validar esse PR,  adicione as variáveis de ambiente disponiveis no arquivo .env-sentry que se encontra no bitwarden ao arquivo .env que você possui.