### PR TITLE
Corrige problemas de importação em MessageChannel e TextEncoder/Decoder quando rodando testes do jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -111,6 +111,7 @@ const config: Config = {
         "^@app/(.*)$": "<rootDir>/src/app/$1",
         "^@features/(.*)$": "<rootDir>/src/features/$1",
         "^common/(.*)$": "<rootDir>/src/common/$1",
+        "react-dom/server": "react-dom/server.edge", // https://stackoverflow.com/questions/79506842/react-19-jest-let-test-cases-failed-with-error-referenceerror-messagechannel
     },
 
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,2 +1,11 @@
 import "@testing-library/jest-dom";
 require("dotenv").config();
+
+// -----------------------------------------------------
+//Hack necessário para resolver problema de importação de TextEncoder e TextDecoder no jsdom (usado pra rodar testes no jest).
+// Solução encontrada aqui: https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-defined-in-jest
+// Mais contexto aqui: https://github.com/jsdom/jsdom/pull/3791
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(global, { TextDecoder, TextEncoder });
+// -----------------------------------------------------


### PR DESCRIPTION
Toda vez que fazemos um teste que renderiza componentes na tela sem mockar (especialmente do design system), estamos recebendo erros de importação do `MessageChannel`. Ao corrigir este erro, o mesmo acontece com `TextEncoder` e `TextDecoder`.

Este PR corrige ambos os problemas, liberando este tipo de teste para o futuro.