### PR TITLE
Ordena opções de filtro no backend

### DIFF
--- a/src/features/acf/backend/hypertension/modules/filters/repository.ts
+++ b/src/features/acf/backend/hypertension/modules/filters/repository.ts
@@ -20,6 +20,9 @@ const fieldOptions = async <TField extends keyof HypertensionAcfItem>(
         },
         distinct: [field],
         where: whereFields,
+        orderBy: {
+            [field]: "asc",
+        },
     });
     return result.map((item) => item[field]);
 };

--- a/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/CoapsFiltersBar/logic.ts
+++ b/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/CoapsFiltersBar/logic.ts
@@ -10,9 +10,9 @@ export const toSelectConfigsCoaps = (
     return [
         ...toSelectConfigsShared(filtersValues),
         {
-            options: toHtmlSelectOptions(filtersValues.careTeamName)
-                .map((item) => ({ ...item, label: nameFormatter(item.label) }))
-                .sort((a, b) => a.label.localeCompare(b.label)),
+            options: toHtmlSelectOptions(filtersValues.careTeamName).map(
+                (item) => ({ ...item, label: nameFormatter(item.label) })
+            ),
             label: "Equipe",
             id: "careTeamName",
             isMultiSelect: true,

--- a/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/common/SharedSelectConfigs.ts
+++ b/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/common/SharedSelectConfigs.ts
@@ -8,9 +8,9 @@ export const toSelectConfigsShared = (
 ): Array<SelectConfig> => {
     return [
         {
-            options: toHtmlSelectOptions(filtersValues.microAreaName)
-                .map((item) => ({ ...item, label: nameFormatter(item.label) }))
-                .sort((a, b) => a.label.localeCompare(b.label)),
+            options: toHtmlSelectOptions(filtersValues.microAreaName).map(
+                (item) => ({ ...item, label: nameFormatter(item.label) })
+            ),
             label: "Microárea",
             id: "microAreaName",
             isMultiSelect: true,
@@ -19,7 +19,7 @@ export const toSelectConfigsShared = (
         {
             options: toHtmlSelectOptions(
                 filtersValues.appointmentStatusByQuarter
-            ).sort((a, b) => a.label.localeCompare(b.label)),
+            ),
             label: "Consulta",
             id: "appointmentStatusByQuarter",
             isMultiSelect: true,
@@ -28,16 +28,14 @@ export const toSelectConfigsShared = (
         {
             options: toHtmlSelectOptions(
                 filtersValues.latestExamRequestStatusByQuarter
-            ).sort((a, b) => a.label.localeCompare(b.label)),
+            ),
             label: "Aferição de PA",
             id: "latestExamRequestStatusByQuarter",
             isMultiSelect: true,
             width: "232px",
         },
         {
-            options: toHtmlSelectOptions(filtersValues.patientAgeRange).sort(
-                (a, b) => a.label.localeCompare(b.label)
-            ),
+            options: toHtmlSelectOptions(filtersValues.patientAgeRange),
             label: "Faixa Etária",
             id: "patientAgeRange",
             isMultiSelect: false,


### PR DESCRIPTION
Este PR ordena as opções de filtro exibidos na página de hipertensão dentro do repository do endpoint de filtros.

Fixes ALOG-520, ALOG-514