### PR TITLE
Aumenta largura do filtro de Aferição de PA

### DIFF
--- a/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/common/SharedSelectConfigs.ts
+++ b/src/features/acf/frontend/hypertension/modules/AcfPage/modules/List/modules/common/SharedSelectConfigs.ts
@@ -35,7 +35,7 @@ export const toSelectConfigsShared = (
             label: "Aferição de PA",
             id: "latestExamRequestStatusByQuarter",
             isMultiSelect: true,
-            width: "232px",
+            width: "282px",
         },
         {
             options: toHtmlSelectOptions(filtersValues.patientAgeRange),


### PR DESCRIPTION
Este PR aumenta a largura do filtro de Aferição de PA para comportar a opção com maior texto + a tag que quantifica as outras opções selecionadas.

Fixes ALOG-524