### PR TITLE
Separa actions de teste

### DIFF
--- a/.github/workflows/pr-integration-test.yml
+++ b/.github/workflows/pr-integration-test.yml
@@ -1,0 +1,31 @@
+name: Integration Tests
+
+permissions:
+    contents: read
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    Integration-Tests:
+        name: Integration Tests
+        runs-on: ubuntu-latest
+        env:
+            NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: "23"
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Run Jest tests
+              run: yarn test:integration

--- a/.github/workflows/pr-unit-test.yml
+++ b/.github/workflows/pr-unit-test.yml
@@ -1,4 +1,3 @@
-# TODO: queremos criar actions separadas para testes de integração?
 name: Unit Tests
 
 permissions:
@@ -13,8 +12,6 @@ jobs:
     NextJS-Tests:
         name: Unit Tests
         runs-on: ubuntu-latest
-        env:
-            NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
 
         steps:
             - name: Checkout code
@@ -30,4 +27,4 @@ jobs:
                   yarn install
 
             - name: Run Jest tests
-              run: yarn test
+              run: yarn test:unit

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "test": "jest",
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage --watchAll=false --bail",
-        "test:integration": "jest __tests__/integration"
+        "test:integration": "jest __tests__/integration",
+        "test:unit": "jest --testPathIgnorePatterns=__tests__/integration"
     },
     "dependencies": {
         "@hotjar/browser": "^1.0.9",


### PR DESCRIPTION
A partir do PR https://github.com/ImpulsoGov/ImpulsoPrevine/pull/489, tornou-se necessário separar as actions que executam os testes da aplicação, já que agora temos também testes de integração.

Este PR adiciona a action de teste unitário e a de teste de integração.

Fixes ALOG-580