### PR TITLE
Adiciona teste de integração da rota de filtros de hipertensão

### DIFF
--- a/__tests__/helpers/auth.ts
+++ b/__tests__/helpers/auth.ts
@@ -19,6 +19,7 @@ export const mockDecodeToken = (): jest.Mock<() => Promise<JWTToken>> => {
     return mockedDecodeToken;
 };
 
+// TODO: rever a possibilidades de expor funções com valores resolvidos
 export const decodedToken = (overrides: DeepPartial<JWTToken>): JWTToken => {
     const defaultToken = {
         payload: {

--- a/__tests__/helpers/db.ts
+++ b/__tests__/helpers/db.ts
@@ -3,7 +3,11 @@
  */
 
 import { jest } from "@jest/globals";
-import type { DiabetesAcfItem, PrismaClient } from "@prisma/client";
+import type {
+    DiabetesAcfItem,
+    PrismaClient,
+    HypertensionAcfItem,
+} from "@prisma/client";
 import { type DeepMockProxy, mockDeep } from "jest-mock-extended";
 
 export const diabetesItem = (
@@ -26,6 +30,28 @@ export const diabetesItem = (
     careTeamName: "Equipe Teste",
     communityHealthWorker: "ACS Teste",
     mostRecentProductionRecordDate: new Date("2024-01-01"),
+    ...overrides,
+});
+
+export const hypertensionItem = (
+    overrides: Partial<HypertensionAcfItem> = {}
+): HypertensionAcfItem => ({
+    patientId: "1",
+    municipalitySusId: "111111",
+    patientName: "Test Patient",
+    patientAge: 45,
+    patientAgeRange: 30,
+    careTeamIne: "123",
+    careTeamName: "Equipe Teste",
+    municipalityName: "Demo",
+    patientCpf: "12345678901",
+    patientCns: null,
+    patientPhoneNumber: null,
+    microAreaName: null,
+    latestAppointmentDate: null,
+    appointmentStatusByQuarter: 30,
+    latestExamRequestDate: null,
+    latestExamRequestStatusByQuarter: 30,
     ...overrides,
 });
 

--- a/__tests__/helpers/flag.ts
+++ b/__tests__/helpers/flag.ts
@@ -4,6 +4,7 @@ import type * as Flags from "@/features/common/shared/flags";
 export const DIABETES_NEW_PROGRAM = "diabetesNewProgram";
 export const HYPERTENSION_NEW_PROGRAM = "hypertensionNewProgram";
 
+// TODO: rever a possibilidades de expor funções com valores resolvidos
 export const mockFlag = (
     name: keyof typeof Flags
 ): jest.Mock<() => Promise<boolean>> => {

--- a/__tests__/helpers/flag.ts
+++ b/__tests__/helpers/flag.ts
@@ -1,6 +1,23 @@
 import { jest } from "@jest/globals";
+import type * as Flags from "@/features/common/shared/flags";
 
-// TODO: generalizar para fazer mock de outras flags também
+export const DIABETES_NEW_PROGRAM = "diabetesNewProgram";
+export const HYPERTENSION_NEW_PROGRAM = "hypertensionNewProgram";
+
+export const mockFlag = (
+    name: keyof typeof Flags
+): jest.Mock<() => Promise<boolean>> => {
+    const mockedFlag = jest.fn<() => Promise<boolean>>();
+
+    jest.doMock("@/features/common/shared/flags", () => ({
+        ...jest.requireActual<typeof Flags>("@/features/common/shared/flags"),
+        [name]: mockedFlag,
+    }));
+
+    return mockedFlag;
+};
+
+// TODO: remover essa função e usar mockFlag no lugar
 export const mockDiabetesNewProgram = (): jest.Mock<() => Promise<boolean>> => {
     const mockedDiabetesNewProgram = jest.fn<() => Promise<boolean>>();
 

--- a/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
+++ b/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
@@ -15,7 +15,7 @@ const coapsUrl =
 const user = {
     municipalitySusId: "111111",
     teamIne: "123",
-    profiles: [PROFILE_ID.COEQ],
+    profiles: [PROFILE_ID.COAPS],
 } satisfies interceptors.User;
 
 describe("/api/lista-nominal/hypertension/filters/coaps Route Handler", () => {

--- a/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
+++ b/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
@@ -36,7 +36,9 @@ describe("/api/lista-nominal/hypertension/filters/coaps Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COAPS] },
+                    })
                 );
             dbHelpers.mockPrismaClient();
 
@@ -56,7 +58,9 @@ describe("/api/lista-nominal/hypertension/filters/coaps Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COEQ] },
+                    })
                 );
             dbHelpers.mockPrismaClient();
 
@@ -94,7 +98,9 @@ describe("/api/lista-nominal/hypertension/filters/coaps Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COAPS] },
+                    })
                 );
 
             const mockedPrisma = dbHelpers.mockPrismaClient();

--- a/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
+++ b/__tests__/integration/api/lista-nominal/hypertension/filters/coaps/route.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment node
+ */
+
+import { PROFILE_ID } from "@/types/profile";
+import type * as interceptors from "@features/interceptors/backend/index";
+import { describe, jest } from "@jest/globals";
+import * as dbHelpers from "@tests/helpers/db";
+import * as httpHelpers from "@tests/helpers/http";
+import * as authHelpers from "@tests/helpers/auth";
+import * as flagHelpers from "@tests/helpers/flag";
+
+const coapsUrl =
+    "http://localhost:3000/api/lista-nominal/hypertension/filters/coaps";
+const user = {
+    municipalitySusId: "111111",
+    teamIne: "123",
+    profiles: [PROFILE_ID.COEQ],
+} satisfies interceptors.User;
+
+describe("/api/lista-nominal/hypertension/filters/coaps Route Handler", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("GET /api/lista-nominal/hypertension/filters/coaps", () => {
+        it("Deve retornar 404 se a feature flag hypertensionNewProgram não estiver habilitada", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(false);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                );
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coaps/route"
+            );
+
+            const request = httpHelpers.request(coapsUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(404);
+        });
+
+        it("Deve retornar 403 se o usuário não possuir o perfil permitido na rota", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                );
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coaps/route"
+            );
+
+            const request = httpHelpers.request(coapsUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(403);
+        });
+
+        it("Deve retornar 500 se um erro inesperado for lançado na rota", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockRejectedValue(new Error("Erro genérico"));
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coaps/route"
+            );
+
+            const request = httpHelpers.request(coapsUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(500);
+        });
+
+        it("Deve retornar 200 e as opções de filtro se o request chegar no handler", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                );
+
+            const mockedPrisma = dbHelpers.mockPrismaClient();
+
+            const mockCareTeamNames = [
+                dbHelpers.hypertensionItem({ careTeamName: "Equipe 1" }),
+                dbHelpers.hypertensionItem({ careTeamName: "Equipe 2" }),
+            ];
+
+            const mockMicroAreaNames = [
+                dbHelpers.hypertensionItem({ microAreaName: "01" }),
+                dbHelpers.hypertensionItem({ microAreaName: "02" }),
+            ];
+
+            const mockAppointmentStatusesByQuarter = [
+                dbHelpers.hypertensionItem({ appointmentStatusByQuarter: 20 }),
+                dbHelpers.hypertensionItem({ appointmentStatusByQuarter: 40 }),
+            ];
+
+            const mockLatestExamRequestStatusesByQuarter = [
+                dbHelpers.hypertensionItem({
+                    latestExamRequestStatusByQuarter: 10,
+                }),
+                dbHelpers.hypertensionItem({
+                    latestExamRequestStatusByQuarter: 20,
+                }),
+            ];
+
+            const mockPatientAgeRanges = [
+                dbHelpers.hypertensionItem({ patientAgeRange: 20 }),
+                dbHelpers.hypertensionItem({ patientAgeRange: 30 }),
+            ];
+
+            mockedPrisma.hypertensionAcfItem.findMany
+                .mockResolvedValueOnce(mockCareTeamNames)
+                .mockResolvedValueOnce(mockMicroAreaNames)
+                .mockResolvedValueOnce(mockAppointmentStatusesByQuarter)
+                .mockResolvedValueOnce(mockLatestExamRequestStatusesByQuarter)
+                .mockResolvedValueOnce(mockPatientAgeRanges);
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coaps/route"
+            );
+
+            const expectedBody = {
+                filters: {
+                    microAreaName: ["01", "02"],
+                    appointmentStatusByQuarter: ["Atrasada", "Em dia"],
+                    latestExamRequestStatusByQuarter: [
+                        "Nunca realizado",
+                        "Atrasada",
+                    ],
+                    patientAgeRange: [
+                        "11 a 19 (Adolescente)",
+                        "20 a 59 (Adulto)",
+                    ],
+                    careTeamName: ["Equipe 1", "Equipe 2"],
+                },
+            };
+
+            const request = httpHelpers.request(coapsUrl, "GET");
+            const response = await GET(request, { user: user });
+
+            expect(response.status).toBe(200);
+            expect(await response.json()).toEqual(expectedBody);
+        });
+    });
+});

--- a/__tests__/integration/api/lista-nominal/hypertension/filters/coeq/route.test.ts
+++ b/__tests__/integration/api/lista-nominal/hypertension/filters/coeq/route.test.ts
@@ -36,7 +36,9 @@ describe("/api/lista-nominal/hypertension/filters/coeq Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COEQ] },
+                    })
                 );
             dbHelpers.mockPrismaClient();
 
@@ -56,7 +58,9 @@ describe("/api/lista-nominal/hypertension/filters/coeq Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COAPS] },
+                    })
                 );
             dbHelpers.mockPrismaClient();
 
@@ -94,7 +98,9 @@ describe("/api/lista-nominal/hypertension/filters/coeq Route Handler", () => {
             authHelpers
                 .mockDecodeToken()
                 .mockResolvedValue(
-                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                    authHelpers.decodedToken({
+                        payload: { perfis: [PROFILE_ID.COEQ] },
+                    })
                 );
 
             const mockedPrisma = dbHelpers.mockPrismaClient();

--- a/__tests__/integration/api/lista-nominal/hypertension/filters/coeq/route.test.ts
+++ b/__tests__/integration/api/lista-nominal/hypertension/filters/coeq/route.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment node
+ */
+
+import { PROFILE_ID } from "@/types/profile";
+import type * as interceptors from "@features/interceptors/backend/index";
+import { describe, jest } from "@jest/globals";
+import * as dbHelpers from "@tests/helpers/db";
+import * as httpHelpers from "@tests/helpers/http";
+import * as authHelpers from "@tests/helpers/auth";
+import * as flagHelpers from "@tests/helpers/flag";
+
+const coeqUrl =
+    "http://localhost:3000/api/lista-nominal/hypertension/filters/coeq";
+const user = {
+    municipalitySusId: "111111",
+    teamIne: "123",
+    profiles: [PROFILE_ID.COEQ],
+} satisfies interceptors.User;
+
+describe("/api/lista-nominal/hypertension/filters/coeq Route Handler", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("GET /api/lista-nominal/hypertension/filters/coeq", () => {
+        it("Deve retornar 404 se a feature flag hypertensionNewProgram não estiver habilitada", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(false);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                );
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coeq/route"
+            );
+
+            const request = httpHelpers.request(coeqUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(404);
+        });
+
+        it("Deve retornar 403 se o usuário não possuir o perfil permitido na rota", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COAPS] })
+                );
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coeq/route"
+            );
+
+            const request = httpHelpers.request(coeqUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(403);
+        });
+
+        it("Deve retornar 500 se um erro inesperado for lançado na rota", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockRejectedValue(new Error("Erro genérico"));
+            dbHelpers.mockPrismaClient();
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coeq/route"
+            );
+
+            const request = httpHelpers.request(coeqUrl, "GET");
+            const response = await GET(request, { user: user });
+            expect(response.status).toBe(500);
+        });
+
+        it("Deve retornar 200 e as opções de filtro se o request chegar no handler", async () => {
+            flagHelpers
+                .mockFlag(flagHelpers.HYPERTENSION_NEW_PROGRAM)
+                .mockResolvedValue(true);
+            authHelpers
+                .mockDecodeToken()
+                .mockResolvedValue(
+                    authHelpers.decodedToken({ perfis: [PROFILE_ID.COEQ] })
+                );
+
+            const mockedPrisma = dbHelpers.mockPrismaClient();
+
+            const mockMicroAreaNames = [
+                dbHelpers.hypertensionItem({ microAreaName: "01" }),
+                dbHelpers.hypertensionItem({ microAreaName: "02" }),
+            ];
+
+            const mockAppointmentStatusesByQuarter = [
+                dbHelpers.hypertensionItem({ appointmentStatusByQuarter: 20 }),
+                dbHelpers.hypertensionItem({ appointmentStatusByQuarter: 40 }),
+            ];
+
+            const mockLatestExamRequestStatusesByQuarter = [
+                dbHelpers.hypertensionItem({
+                    latestExamRequestStatusByQuarter: 10,
+                }),
+                dbHelpers.hypertensionItem({
+                    latestExamRequestStatusByQuarter: 20,
+                }),
+            ];
+
+            const mockPatientAgeRanges = [
+                dbHelpers.hypertensionItem({ patientAgeRange: 20 }),
+                dbHelpers.hypertensionItem({ patientAgeRange: 30 }),
+            ];
+
+            mockedPrisma.hypertensionAcfItem.findMany
+                .mockResolvedValueOnce(mockMicroAreaNames)
+                .mockResolvedValueOnce(mockAppointmentStatusesByQuarter)
+                .mockResolvedValueOnce(mockLatestExamRequestStatusesByQuarter)
+                .mockResolvedValueOnce(mockPatientAgeRanges);
+
+            const { GET } = await import(
+                "@/app/api/lista-nominal/hypertension/filters/coeq/route"
+            );
+
+            const expectedBody = {
+                filters: {
+                    microAreaName: ["01", "02"],
+                    appointmentStatusByQuarter: ["Atrasada", "Em dia"],
+                    latestExamRequestStatusByQuarter: [
+                        "Nunca realizado",
+                        "Atrasada",
+                    ],
+                    patientAgeRange: [
+                        "11 a 19 (Adolescente)",
+                        "20 a 59 (Adulto)",
+                    ],
+                },
+            };
+
+            const request = httpHelpers.request(coeqUrl, "GET");
+            const response = await GET(request, { user: user });
+
+            expect(response.status).toBe(200);
+            expect(await response.json()).toEqual(expectedBody);
+        });
+    });
+});


### PR DESCRIPTION
Este PR adiciona testes de integração para os endpoints `/api/lista-nominal/hypertension/filters/coaps` e `/api/lista-nominal/hypertension/filters/coeq`, além de:
- Criar um helper genérico para fazer mock das flags
  - **OBS:** a substituição e remoção do helper `mockDiabetesNewProgram` será feita num PR separado para manter os PRs com uma quantidade razoável de mudanças.

Fixes ALOG-579