### PR TITLE
[COFIN25] Amplia acessoa das listas de diabetes e hipertensão - Onda 11

### DIFF
--- a/src/features/common/shared/flags/modules/diabetesNewProgram.ts
+++ b/src/features/common/shared/flags/modules/diabetesNewProgram.ts
@@ -202,6 +202,10 @@ const allowedMunicipalities = [
     "270750",
     "211300",
     "312650",
+    "221130",
+    "230860",
+    "313660",
+    "130140",
 ];
 
 export const diabetesNewProgram = flag<

--- a/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
+++ b/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
@@ -202,6 +202,10 @@ const allowedMunicipalities = [
     "270750",
     "211300",
     "312650",
+    "221130",
+    "230860",
+    "313660",
+    "130140",
 ];
 
 export const hypertensionNewProgram = flag<


### PR DESCRIPTION
Municípios contemplados na Onda 11:
- Valença do Piauí - PI	221130
- Monsenhor Tabosa - CE	230860
- Nova União - MG	313660
- Eirunepé - AM	130140