### PR TITLE
[COFIN25] Amplia acesso das listas de hipertensão e diabetes - Onda 14

### DIFF
--- a/src/features/common/shared/flags/modules/diabetesNewProgram.ts
+++ b/src/features/common/shared/flags/modules/diabetesNewProgram.ts
@@ -218,6 +218,12 @@ const allowedMunicipalities = [
     "312737",
     "260880",
     "150670",
+    "310240",
+    "220190",
+    "130150",
+    "260470",
+    "231195",
+    "311440",
 ];
 
 export const diabetesNewProgram = flag<

--- a/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
+++ b/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
@@ -218,6 +218,12 @@ const allowedMunicipalities = [
     "312737",
     "260880",
     "150670",
+    "310240",
+    "220190",
+    "130150",
+    "260470",
+    "231195",
+    "311440",
 ];
 
 export const hypertensionNewProgram = flag<


### PR DESCRIPTION
Municípios integrantes da Onda 14:

- 310240 | Alvorada de Minas - MG
- 220190 | Bom Jesus - PI
- 130150 | Envira - AM
- 260470 | Correntes - PE
- 231195 | Salitre - CE
- 311440 | Carmo do Rio Claro - MG