### PR TITLE
[COFIN25] Amplia acesso das listas de hipertensão e diabetes - Onda 17

### DIFF
--- a/src/features/common/shared/flags/modules/diabetesNewProgram.ts
+++ b/src/features/common/shared/flags/modules/diabetesNewProgram.ts
@@ -246,6 +246,8 @@ const allowedMunicipalities = [
     "355710",
     "211400",
     "261370",
+    "290070",
+    "210047",
 ];
 
 export const diabetesNewProgram = flag<

--- a/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
+++ b/src/features/common/shared/flags/modules/hypertensionNewProgram.ts
@@ -246,6 +246,8 @@ const allowedMunicipalities = [
     "355710",
     "211400",
     "261370",
+    "290070",
+    "210047",
 ];
 
 export const hypertensionNewProgram = flag<


### PR DESCRIPTION
## Resumo
Adiciona municípios da Onda 17 nas flags das listas de diabetes e hipertensão do Impulso Previne.

Municípios contemplados na Onda 17:
- Alagoinhas - BA | 290070
- Alto Alegre do Pindaré - MA | 210047