### PR TITLE
feat: remove itens de menu (Novos Indicadores e FAQ)

### DIFF
--- a/src/helpers/menuNavBar.ts
+++ b/src/helpers/menuNavBar.ts
@@ -119,7 +119,6 @@ const notLoggedMenu = (): Array<Menu> => {
     return [
         { label: "Quem Somos", url: "/quem-somos" },
         { label: "Dados do SISAB", url: "/analise" },
-        { label: "FAQ", url: "/faq" },
         { label: "Blog", url: "/blog" },
     ];
 };

--- a/src/helpers/menuNavBar.ts
+++ b/src/helpers/menuNavBar.ts
@@ -110,11 +110,6 @@ const loggedMenu = async (
             url: "/analise",
             telemetryEvent: "acessar_pg_dados_sisab",
         },
-        {
-            label: "Entenda os Novos Indicadores",
-            url: "https://impulsogov-2jxn.help.userguiding.com/pt/categories/3587-novos-indicadores-da-aps",
-            telemetryEvent: "acessar_pg_faq_novos_indicadores",
-        },
     ];
 
     return menus;


### PR DESCRIPTION
## Descrição

Remove itens da barra de navegação:

- **Menu logado:** remove "Entenda os Novos Indicadores", que apontava para a categoria de FAQ "Novos Indicadores da APS" no UserGuiding, junto com o evento de telemetria `acessar_pg_faq_novos_indicadores`.
- **Menu não logado:** remove o item "FAQ" (`/faq`).