### PR TITLE
feat: redireciona municípios migrados para o PortalImpulso

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ ALLOWED_ORIGINS_PROD = ['https://www.minhaaplicacao.com']
 # CPF do usuário de teste
 TEST_USER = 12312312312
 TEST_USER_PASSWORD= senha_do_usuario_de_teste
+
+# URL do PortalImpulso, para onde municípios migrados são redirecionados
+PORTAL_IMPULSO_URL=https://www.portalimpulso.com/rota

--- a/src/middlewares/middlewarePages.ts
+++ b/src/middlewares/middlewarePages.ts
@@ -1,6 +1,11 @@
 import { matchesRoute } from "@/features/common/frontend/path";
 import { getToken } from "next-auth/jwt";
 import { type NextRequest, NextResponse } from "next/server";
+import {
+    buildPortalImpulsoUrl,
+    isMunicipioMigrado,
+    isNavigation,
+} from "./portalImpulsoRedirect";
 
 export const rotasPublicas = [
     "/",
@@ -67,6 +72,19 @@ export const middlewarePages = async (
         };
     } | null;
     let response = NextResponse.next();
+
+    if (
+        token &&
+        isNavigation(request) &&
+        matchesRoute(rotasProtegidas, url.pathname) &&
+        isMunicipioMigrado(token.user.municipio_id_sus)
+    ) {
+        const target = buildPortalImpulsoUrl(
+            process.env.PORTAL_IMPULSO_URL ?? ""
+        );
+        if (target && target.origin !== url.origin)
+            return NextResponse.redirect(target);
+    }
 
     if (
         token &&

--- a/src/middlewares/portalImpulsoRedirect.ts
+++ b/src/middlewares/portalImpulsoRedirect.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+
+const municipiosMigrados = [
+    "111111",
+    // TODO: códigos SUS dos municípios migrados para o PortalImpulso
+];
+
+export const isMunicipioMigrado = (municipioIdSus: string): boolean =>
+    municipiosMigrados.includes(municipioIdSus);
+
+export const buildPortalImpulsoUrl = (baseUrl: string): URL | null => {
+    if (!baseUrl) return null;
+    try {
+        const url = new URL(baseUrl);
+        url.searchParams.set("usuario_do_ip", "true");
+        return url;
+    } catch {
+        return null;
+    }
+};
+
+export const isNavigation = (request: NextRequest): boolean =>
+    request.headers.get("RSC") !== "1" &&
+    request.headers.get("next-router-prefetch") !== "1" &&
+    request.headers.get("sec-fetch-mode") === "navigate";


### PR DESCRIPTION
## Contexto

O ImpulsoPrevine está sendo descontinuado em favor do **PortalImpulso**. Usuários autenticados de municípios migrados devem ser redirecionados para o PortalImpulso com `?usuario_do_ip=true`, em **todo** acesso a página protegida (não só no login).

## Como funciona

- `src/middlewares/portalImpulsoRedirect.ts` (novo): lista de códigos SUS dos municípios migrados (`isMunicipioMigrado`), montagem da URL de destino com fail-open se a env var estiver ausente/inválida (`buildPortalImpulsoUrl`), e guarda contra prefetch/RSC (`isNavigation`).
- `src/middlewares/middlewarePages.ts`: após o `getToken`, se o usuário está autenticado, é uma navegação de documento, a rota é protegida e o município está na lista → 307 para `PORTAL_IMPULSO_URL` + `?usuario_do_ip=true`.
- Decisão de implementação: checagem direta na lista usando o `municipio_id_sus` já decodificado do token, **sem** o SDK de feature flags — o SDK não pode ser importado em `middlewarePages.ts` (o `Base.tsx` importa as rotas desse arquivo, o que puxaria `async_hooks` para o bundle do browser e quebra o build), e refatorar não vale a pena num codebase em descontinuação.


## Importante!

- Município na lista perde acesso a **todas** as rotas protegidas, incluindo `/termos-uso-e-privacidade`. Logout continua funcionando (`/api/auth/*` não passa por esse código). Páginas públicas continuam acessíveis.


## Verificação

- `yarn build` passa (bundle de middleware: 161 kB).
- Verificação manual pendente conforme plano: login com município na lista → redireciona; fora da lista → fluxo normal; env var ausente → fail-open.