### PR TITLE
feat: redireciona municípios migrados também em rotas públicas

### DIFF
--- a/src/middlewares/middlewarePages.ts
+++ b/src/middlewares/middlewarePages.ts
@@ -77,6 +77,7 @@ export const middlewarePages = async (
         token &&
         isNavigation(request) &&
         matchesRoute(rotasProtegidas, url.pathname) &&
+        matchesRoute(rotasPublicas, url.pathname) &&
         isMunicipioMigrado(token.user.municipio_id_sus)
     ) {
         const target = buildPortalImpulsoUrl(

--- a/src/middlewares/middlewarePages.ts
+++ b/src/middlewares/middlewarePages.ts
@@ -76,8 +76,8 @@ export const middlewarePages = async (
     if (
         token &&
         isNavigation(request) &&
-        matchesRoute(rotasProtegidas, url.pathname) &&
-        matchesRoute(rotasPublicas, url.pathname) &&
+        (matchesRoute(rotasProtegidas, url.pathname) ||
+            matchesRoute(rotasPublicas, url.pathname)) &&
         isMunicipioMigrado(token.user.municipio_id_sus)
     ) {
         const target = buildPortalImpulsoUrl(


### PR DESCRIPTION
Amplia a condição do redirecionamento para o PortalImpulso em `middlewarePages.ts`: usuários logados de municípios migrados são redirecionados em qualquer rota protegida **ou** pública (`/`, `/blog`, `/quem-somos` etc.), inclusive quem chega já autenticado.

Substitui a parte de rotas do PR #688.